### PR TITLE
pref(qwen38): deep context, Q8 KV and Windows release optimize

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -183,7 +183,7 @@ jobs:
           if ($LASTEXITCODE -ne 0) { exit $LASTEXITCODE }
           cargo test --locked -p infr-core hostmem::tests::the_windows_live_probe_is_plausible -- --exact
           if ($LASTEXITCODE -ne 0) { exit $LASTEXITCODE }
-      - name: Build portable infr.exe
+      - name: Build portable MoE4All engine (infr.exe)
         run: cargo build --release --locked -p infr-cli
       - name: Package and smoke-test the CMD distribution
         shell: pwsh
@@ -192,7 +192,7 @@ jobs:
           if ($LASTEXITCODE -ne 0) { throw "cargo metadata failed with exit code $LASTEXITCODE" }
           $version = [string](($metadata.packages | Where-Object { $_.name -eq 'infr-cli' } | Select-Object -First 1).version)
           .\scripts\package-windows.ps1 -OutputDirectory 'target\ci-dist' -Version $version
-          $packageName = "infr-windows-x86_64-$version"
+          $packageName = "MoE4All-Windows-x86_64-v$version"
           $archivePath = Join-Path 'target\ci-dist' "$packageName.zip"
           $extractPath = Join-Path $env:RUNNER_TEMP 'infr-package-smoke'
           Expand-Archive -LiteralPath $archivePath -DestinationPath $extractPath

--- a/.github/workflows/release-windows.yml
+++ b/.github/workflows/release-windows.yml
@@ -23,7 +23,7 @@ env:
 
 jobs:
   package:
-    name: Build Windows release package
+    name: Build MoE4All Windows package
     runs-on: windows-2025
     timeout-minutes: 90
     permissions:
@@ -55,7 +55,7 @@ jobs:
           if ('${{ github.event_name }}' -eq 'push' -and '${{ github.ref_name }}' -ne $expectedTag) {
             throw "Tag '${{ github.ref_name }}' does not match Cargo version '$expectedTag'."
           }
-          $packageName = "infr-windows-x86_64-$version"
+          $packageName = "MoE4All-Windows-x86_64-v$version"
           "version=$version" | Out-File -FilePath $env:GITHUB_OUTPUT -Encoding utf8 -Append
           "package_name=$packageName" | Out-File -FilePath $env:GITHUB_OUTPUT -Encoding utf8 -Append
           "archive_name=$packageName.zip" | Out-File -FilePath $env:GITHUB_OUTPUT -Encoding utf8 -Append
@@ -78,7 +78,7 @@ jobs:
           if ($LASTEXITCODE -ne 0) { exit $LASTEXITCODE }
           cargo test --locked -p infr-core hostmem::tests::the_windows_live_probe_is_plausible -- --exact
           if ($LASTEXITCODE -ne 0) { exit $LASTEXITCODE }
-      - name: Build portable infr.exe
+      - name: Build portable MoE4All engine (infr.exe)
         run: cargo build --release --locked -p infr-cli
 
       - name: Create release archive
@@ -122,7 +122,9 @@ jobs:
           & gh release view $tag *> $null
           if ($LASTEXITCODE -eq 0) {
             & gh release upload $tag @assets --clobber
+            if ($LASTEXITCODE -ne 0) { throw "GitHub Release upload failed with exit code $LASTEXITCODE" }
+            & gh release edit $tag --title "MoE4All v${{ steps.release.outputs.version }}"
           } else {
-            & gh release create $tag @assets --verify-tag --title "INFR ${{ steps.release.outputs.version }}" --generate-notes
+            & gh release create $tag @assets --verify-tag --title "MoE4All v${{ steps.release.outputs.version }}" --generate-notes
           }
           if ($LASTEXITCODE -ne 0) { throw "GitHub Release publish failed with exit code $LASTEXITCODE" }

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,28 @@ The format follows [Keep a Changelog](https://keepachangelog.com/en/1.1.0/).
 
 ## [Unreleased]
 
+## [0.3.0] - 2026-08-27
+
+### Added
+
+- The Windows launch wizard now shows the MoE4All version, project identity,
+  maintainer, and repository, and checks GitHub Releases for updates without
+  blocking offline startup.
+- A GGUF can be dropped directly onto `Start-INFR-Wizard.cmd` or passed as its
+  first argument. Existing history selection and in-terminal path pasting remain
+  available.
+
+### Changed
+
+- Windows archives and workflow artifacts are named
+  `MoE4All-Windows-x86_64-vVERSION.zip`; the engine remains `infr.exe` for CLI
+  and script compatibility.
+- GitHub Release titles use `MoE4All vVERSION`, and package smoke tests now cover
+  the bilingual documentation, version banner, all three wizard modes, and the
+  direct model-path argument.
+- Links from packaged documentation to repository-only technical material use
+  GitHub URLs, so they remain valid outside a source checkout.
+
 ## [0.2.0] - 2026-08-27
 
 ### Highlights

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1124,7 +1124,7 @@ dependencies = [
 
 [[package]]
 name = "infr-chat"
-version = "0.2.0"
+version = "0.3.0"
 dependencies = [
  "chrono",
  "infr-core",
@@ -1139,7 +1139,7 @@ dependencies = [
 
 [[package]]
 name = "infr-cli"
-version = "0.2.0"
+version = "0.3.0"
 dependencies = [
  "anyhow",
  "clap",
@@ -1163,7 +1163,7 @@ dependencies = [
 
 [[package]]
 name = "infr-core"
-version = "0.2.0"
+version = "0.3.0"
 dependencies = [
  "bytemuck",
  "half",
@@ -1181,7 +1181,7 @@ dependencies = [
 
 [[package]]
 name = "infr-cpu"
-version = "0.2.0"
+version = "0.3.0"
 dependencies = [
  "anyhow",
  "bytemuck",
@@ -1197,7 +1197,7 @@ dependencies = [
 
 [[package]]
 name = "infr-embedding"
-version = "0.2.0"
+version = "0.3.0"
 dependencies = [
  "anyhow",
  "bytemuck",
@@ -1214,7 +1214,7 @@ dependencies = [
 
 [[package]]
 name = "infr-engine"
-version = "0.2.0"
+version = "0.3.0"
 dependencies = [
  "anyhow",
  "infr-chat",
@@ -1228,7 +1228,7 @@ dependencies = [
 
 [[package]]
 name = "infr-gguf"
-version = "0.2.0"
+version = "0.3.0"
 dependencies = [
  "anyhow",
  "bytemuck",
@@ -1244,7 +1244,7 @@ dependencies = [
 
 [[package]]
 name = "infr-gui"
-version = "0.2.0"
+version = "0.3.0"
 dependencies = [
  "anyhow",
  "axum",
@@ -1264,7 +1264,7 @@ dependencies = [
 
 [[package]]
 name = "infr-hub"
-version = "0.2.0"
+version = "0.3.0"
 dependencies = [
  "dirs",
  "indicatif",
@@ -1281,7 +1281,7 @@ dependencies = [
 
 [[package]]
 name = "infr-llama"
-version = "0.2.0"
+version = "0.3.0"
 dependencies = [
  "anyhow",
  "bytemuck",
@@ -1304,7 +1304,7 @@ dependencies = [
 
 [[package]]
 name = "infr-metal"
-version = "0.2.0"
+version = "0.3.0"
 dependencies = [
  "bytemuck",
  "half",
@@ -1320,7 +1320,7 @@ dependencies = [
 
 [[package]]
 name = "infr-prof"
-version = "0.2.0"
+version = "0.3.0"
 dependencies = [
  "proc-macro2",
  "quote",
@@ -1329,11 +1329,11 @@ dependencies = [
 
 [[package]]
 name = "infr-prof-rt"
-version = "0.2.0"
+version = "0.3.0"
 
 [[package]]
 name = "infr-server"
-version = "0.2.0"
+version = "0.3.0"
 dependencies = [
  "anyhow",
  "axum",
@@ -1352,7 +1352,7 @@ dependencies = [
 
 [[package]]
 name = "infr-testkit"
-version = "0.2.0"
+version = "0.3.0"
 dependencies = [
  "bytemuck",
  "half",
@@ -1362,7 +1362,7 @@ dependencies = [
 
 [[package]]
 name = "infr-vulkan"
-version = "0.2.0"
+version = "0.3.0"
 dependencies = [
  "ash",
  "bytemuck",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -20,10 +20,10 @@ members = [
 ]
 
 [workspace.package]
-version = "0.2.0"
+version = "0.3.0"
 edition = "2021"
 license = "Apache-2.0"
-repository = "https://github.com/Headmaster218/infr"
+repository = "https://github.com/Headmaster218/MoE4All"
 
 [workspace.dependencies]
 # internal

--- a/GETTING_STARTED.md
+++ b/GETTING_STARTED.md
@@ -27,7 +27,7 @@ MoE4All 当前重点优化和实测 AMD Radeon。其他带 Vulkan 驱动的 GPU 
 ## 2. 下载和解压
 
 1. 打开 [MoE4All Releases](https://github.com/Headmaster218/MoE4All/releases/latest)。
-2. 下载 `infr-windows-x86_64-版本号.zip`。
+2. 下载 `MoE4All-Windows-x86_64-v版本号.zip`。
 3. 将 ZIP 完整解压到一个普通目录，例如 `D:\MoE4All`。
 4. 不要直接在压缩包预览窗口中运行 CMD，也不要只单独取出 `infr.exe`。
 
@@ -123,9 +123,13 @@ Start-INFR-Wizard.cmd
 
 - 粘贴完整 GGUF 路径；或
 - 把 GGUF 文件拖进已经打开的终端窗口，再按 Enter。
+- 直接把 GGUF 拖到 `Start-INFR-Wizard.cmd` 上，以该模型打开向导。
 
-路径可以包含空格和中文。当前版本尚未把“直接将 GGUF 拖到 CMD 图标上启动”
-接入模型参数；请先打开向导，再将文件拖入模型路径提示处。
+路径可以包含空格和中文。分片模型只需拖入其中一片，建议选择第一片。
+
+向导启动时会检查 GitHub 上的最新 Release。请求超时很短，断网时会直接继续；
+它只提示下载地址，不会自动下载或替换程序。如需完全禁用，可在启动前设置
+`MOE4ALL_NO_UPDATE_CHECK=1`。
 
 ### 自动配置
 
@@ -465,7 +469,8 @@ cargo build --release --locked -p infr-cli
 ```
 
 长期配置建议写入 `infr.toml`，临时实验使用 CLI。环境变量会被子进程继承，容易
-在几天后忘记并影响 benchmark。完整字段见 [配置参考](docs/config.md) 和
+在几天后忘记并影响 benchmark。完整字段见
+[配置参考](https://github.com/Headmaster218/MoE4All/blob/main/docs/config.md) 和
 [`infr.example.toml`](infr.example.toml)。
 
 ## English quick start
@@ -473,12 +478,12 @@ cargo build --release --locked -p infr-cli
 MoE4All's portable Windows package is the recommended path for end users:
 
 1. Install a current AMD GPU driver with Vulkan support.
-2. Download and fully extract the latest `infr-windows-x86_64-*.zip` from
+2. Download and fully extract the latest `MoE4All-Windows-x86_64-v*.zip` from
    [GitHub Releases](https://github.com/Headmaster218/MoE4All/releases/latest).
 3. Download a supported GGUF model. Keep all shards of a split model together.
 4. Double-click `Start-INFR-Wizard.cmd`.
-5. Choose interactive chat and automatic configuration, then paste or drag the
-   GGUF path into the open model-path prompt.
+5. Choose interactive chat and automatic configuration, then paste a GGUF path,
+   drag it into the open prompt, or drop the file directly onto the CMD launcher.
 
 The release package does not require Rust, Visual Studio, or the Vulkan SDK.
 Models are not bundled. Start with a small GGUF to validate the driver and
@@ -492,4 +497,4 @@ recommended baseline.
 For upstream engine documentation, see the original
 [kryptic-sh/infr README](https://github.com/kryptic-sh/infr#readme). MoE4All
 project documentation starts at [README.md](README.md) and
-[docs/README.md](docs/README.md).
+[docs/README.md](https://github.com/Headmaster218/MoE4All/blob/main/docs/README.md).

--- a/README.md
+++ b/README.md
@@ -21,28 +21,31 @@ MoE 模型的专家权重按需在显存、内存和 SSD 之间流动，因此�
 ## 最新进展：完整支持 Qwen3.8-Flash-Next
 
 Qwen3.8-Flash-Next 已经通过 MoE4All 在消费级 **AMD Radeon RX 7900 XTX**
-上稳定生成正常内容，简单数学和推理问题也能够正确回答。首跑使用 Windows 11、
-Q2 量化，实际系统内存占用约 **40 GB**。
+上稳定生成正常内容，简单数学和推理问题也能够正确回答。Q2_K_XL 和 IQ4_XS
+量化均已完成 Windows 11 实测，并可在 **40 GiB bounded RAM** 下从 SSD 分页运行。
 
 当前 `qwen4exp` 文本路径已经完整接入发布模型所需的四流 Hyper-Connection、
 Gated DeltaNet/全注意力混合层、SSD 支持的 PLE、分页 MoE，以及 **QSA 稀疏注意力**。
 QSA 会维护独立的 F16 index-key cache，选择完整历史块并保留未完成的 causal tail，
-因此推理不再受首版约 2K 上下文的临时限制。
+以覆盖长上下文。主 K/V Cache 支持 Q8_0；QSA index-key cache 保持 F16，并独立
+计价和分配。
 
-下表前四项是三次短测的代表值；最后两项是刚完成的 QSA 路径验证。`tg1` 只用于
-确认真实和 synthetic KV 都跨过 QSA 启用边界，不应视为最终长上下文吞吐成绩。
+下表来自 RX 7900 XTX、Vulkan0、Q8 K/V、40 GiB bounded RAM。Decode 使用
+`tg128`，Prefill 使用 `pp1024`，ubatch 为 1024；128K/250K 通过 synthetic depth
+构造真实 KV 长度。表内是三次平均值，所有 12 项均报告 `kv_q8=true`、
+`kv_layout=q8_0`。
 
-| 测试 | 代表值 | 三次范围 |
-|---|---:|---:|
-| 0 context decode，tg16 | **43.5 tok/s** | 42.6-44.9 tok/s |
-| 0 context prefill，pp32 | **46.6 tok/s** | 46.2-47.1 tok/s |
-| 1024 context decode，tg16 | **41.9 tok/s** | 41.4-42.7 tok/s |
-| 1024 context incremental prefill，pp32 | **42.6 tok/s** | 42.1-43.3 tok/s |
-| 真实 prefill 至 depth 2052 后 QSA decode，tg1 | **32.9 tok/s** | 单次路径验证 |
-| synthetic depth 4096 后 QSA decode，tg1 | **22.9 tok/s** | 单次路径验证 |
+| Context depth | Q2_K_XL decode | Q2_K_XL prefill | IQ4_XS decode | IQ4_XS prefill |
+|---:|---:|---:|---:|---:|
+| 0 | **29.45 tok/s** | **155.16 tok/s** | **16.85 tok/s** | **244.68 tok/s** |
+| 128K | **26.23 tok/s** | **170.44 tok/s** | **14.15 tok/s** | **250.55 tok/s** |
+| 250K | **22.82 tok/s** | **152.27 tok/s** | **15.26 tok/s** | **239.00 tok/s** |
 
-QSA 当前采用 correctness-first 的精确选块实现；长上下文 kernel 与端到端性能仍有
-优化空间，但模型架构、缓存分配和实际稀疏注意力数据路径已经贯通。
+Q2 与 IQ4_XS 都通过了三轮真实 API 对话，能够保持校验码、完成跨轮算术并总结
+先前内容。
+
+QSA 当前使用保持 score/index 精确顺序的 radix top-k，并已接入 batched QSA/PLE
+Prefill。Decode 仍明显受专家 RAM/SSD 覆盖率影响，仍有继续优化空间。
 
 ## 三步开始
 
@@ -113,8 +116,10 @@ Windows 11 主机。它们用于说明项目已经达到的能力，不同模型
 | Qwen3.6-35B-A3B，250K synthetic depth 后 prefill 4,096 | Q8 K/V | **477.9 tok/s** |
 | Qwen3.6-35B-A3B，depth 0 prefill 4,096 | Q8 K/V | **2,855.6 tok/s** |
 | Qwen3.5-122B-A10B，depth 0 decode | F16 K/V，45 GiB bounded RAM，3 次重复 | **23.2 tok/s** |
-| Qwen3.8-Flash-Next，真实 depth 2052 后 QSA decode | Q2，F16 K/V，40 GiB bounded RAM，tg1 路径验证 | **32.9 tok/s** |
-| Qwen3.8-Flash-Next，synthetic depth 4096 后 QSA decode | Q2，F16 K/V，40 GiB bounded RAM，tg1 路径验证 | **22.9 tok/s** |
+| Qwen3.8-Flash-Next Q2_K_XL，250K synthetic depth 后 decode | Q8 K/V，40 GiB bounded RAM，tg128，3 次平均 | **22.82 tok/s** |
+| Qwen3.8-Flash-Next Q2_K_XL，250K 后 prefill 1,024 | Q8 K/V，40 GiB bounded RAM，3 次平均 | **152.27 tok/s** |
+| Qwen3.8-Flash-Next IQ4_XS，250K synthetic depth 后 decode | Q8 K/V，40 GiB bounded RAM，tg128，3 次平均 | **15.26 tok/s** |
+| Qwen3.8-Flash-Next IQ4_XS，250K 后 prefill 1,024 | Q8 K/V，40 GiB bounded RAM，3 次平均 | **239.00 tok/s** |
 
 完整条件和优化历史见：
 

--- a/README.md
+++ b/README.md
@@ -6,7 +6,7 @@
 [下载最新版 Windows 程序](https://github.com/Headmaster218/MoE4All/releases/latest) |
 [快速开始](GETTING_STARTED.md) |
 [English](README_EN.md) |
-[技术文档](docs/README.md)
+[技术文档](https://github.com/Headmaster218/MoE4All/blob/main/docs/README.md)
 
 MoE4All 是一个面向 AMD 显卡和 Windows 11 的本地大模型运行项目。它让
 MoE 模型的专家权重按需在显存、内存和 SSD 之间流动，因此模型不必全部塞进
@@ -52,7 +52,7 @@ Prefill。Decode 仍明显受专家 RAM/SSD 覆盖率影响，仍有继续优化
 ### 1. 下载
 
 打开 [最新 Release](https://github.com/Headmaster218/MoE4All/releases/latest)，
-下载 `infr-windows-x86_64-*.zip` 并完整解压。
+下载 `MoE4All-Windows-x86_64-v*.zip` 并完整解压。
 
 发布包已经包含 `infr.exe` 和中英双语启动向导。运行发布版不需要安装 Rust、
 Visual Studio 或 Vulkan SDK，只需要正常的 64 位 AMD 显卡驱动及其 Vulkan
@@ -77,6 +77,9 @@ Start-INFR-Wizard.cmd
 选择终端聊天、OpenAI 兼容 API 或性能测试，然后输入或拖入 GGUF 路径。
 普通用户建议使用“自动配置”：MoE4All 会探测 GPU、可用显存和系统内存，并
 自动规划 KV Cache、运行时空间和专家缓存。
+
+向导启动时会用很短的网络请求检查 GitHub Release；发现新版本时只显示下载
+链接，不会自动修改程序。断网不会阻止启动。
 
 ## 它能做什么
 
@@ -123,9 +126,9 @@ Windows 11 主机。它们用于说明项目已经达到的能力，不同模型
 
 完整条件和优化历史见：
 
-- [Qwen3.6 RX 7900 XTX 优化记录](docs/perf/qwen36-rx7900xtx-optimization-history-20260819.md)
-- [统一显存验收记录](docs/unified-vram-elastic-acceptance-20260824.md)
-- [DeepSeek V4 Flash 收尾记录](docs/perf/deepseek-v4-flash-rx7900xtx-closeout-20260824.md)
+- [Qwen3.6 RX 7900 XTX 优化记录](https://github.com/Headmaster218/MoE4All/blob/main/docs/perf/qwen36-rx7900xtx-optimization-history-20260819.md)
+- [统一显存验收记录](https://github.com/Headmaster218/MoE4All/blob/main/docs/unified-vram-elastic-acceptance-20260824.md)
+- [DeepSeek V4 Flash 收尾记录](https://github.com/Headmaster218/MoE4All/blob/main/docs/perf/deepseek-v4-flash-rx7900xtx-closeout-20260824.md)
 
 ## 当前模型支持
 
@@ -195,8 +198,9 @@ AMD Vulkan 计算
 显存中的模型固定部分、KV Cache、运行时 scratch 和专家缓存由统一预算协调，
 prefill 与 decode 切换时可以重新分配弹性空间。
 
-更深入的实现说明在 [技术文档索引](docs/README.md) 和
-[MoE4All Wiki](infr-fork-wiki/README.md)。
+更深入的实现说明在
+[技术文档索引](https://github.com/Headmaster218/MoE4All/blob/main/docs/README.md) 和
+[MoE4All Wiki](https://github.com/Headmaster218/MoE4All/blob/main/infr-fork-wiki/README.md)。
 
 ## 当前限制
 

--- a/README_EN.md
+++ b/README_EN.md
@@ -5,7 +5,7 @@
 [Latest Windows release](https://github.com/Headmaster218/MoE4All/releases/latest) |
 [Getting started](GETTING_STARTED.md#english-quick-start) |
 [简体中文](README.md) |
-[Technical documentation](docs/README.md)
+[Technical documentation](https://github.com/Headmaster218/MoE4All/blob/main/docs/README.md)
 
 MoE4All is a local LLM inference project focused on AMD GPUs and native
 Windows 11. It moves MoE expert weights between VRAM, system RAM, and SSD on
@@ -57,7 +57,7 @@ and has further optimization headroom.
 ### 1. Download
 
 Open the [latest Release](https://github.com/Headmaster218/MoE4All/releases/latest),
-download `infr-windows-x86_64-*.zip`, and fully extract the archive.
+download `MoE4All-Windows-x86_64-v*.zip`, and fully extract the archive.
 
 The package includes `infr.exe` and the bilingual launch wizard. Running the
 packaged build does not require Rust, Visual Studio, or the Vulkan SDK. It does
@@ -86,6 +86,10 @@ Choose interactive terminal chat, the OpenAI-compatible API, or benchmark
 mode, then paste or drag the GGUF path into the open model prompt. Automatic
 configuration is recommended: MoE4All detects the GPU, available VRAM, system
 memory, model structure, KV requirements, runtime space, and expert cache.
+
+At startup, the wizard makes a short request to check the latest GitHub
+Release. It only displays a download link when an update exists and never
+modifies the installation automatically. Offline startup continues normally.
 
 ## What it does
 
@@ -136,9 +140,9 @@ capabilities; rows use different workloads and are not directly comparable.
 
 Full conditions and engineering history:
 
-- [Qwen3.6 RX 7900 XTX optimization history](docs/perf/qwen36-rx7900xtx-optimization-history-20260819.md)
-- [Unified elastic VRAM acceptance](docs/unified-vram-elastic-acceptance-20260824.md)
-- [DeepSeek V4 Flash closeout](docs/perf/deepseek-v4-flash-rx7900xtx-closeout-20260824.md)
+- [Qwen3.6 RX 7900 XTX optimization history](https://github.com/Headmaster218/MoE4All/blob/main/docs/perf/qwen36-rx7900xtx-optimization-history-20260819.md)
+- [Unified elastic VRAM acceptance](https://github.com/Headmaster218/MoE4All/blob/main/docs/unified-vram-elastic-acceptance-20260824.md)
+- [DeepSeek V4 Flash closeout](https://github.com/Headmaster218/MoE4All/blob/main/docs/perf/deepseek-v4-flash-rx7900xtx-closeout-20260824.md)
 
 ## Current model support
 
@@ -213,8 +217,10 @@ hot tier, and SSD supplies the rest. Fixed model weights, KV caches, runtime
 scratch, and expert residency share a coordinated VRAM budget. Elastic space
 can be reassigned when execution changes between prefill and decode.
 
-For implementation details, see the [documentation index](docs/README.md) and
-the [MoE4All wiki](infr-fork-wiki/README.md).
+For implementation details, see the
+[documentation index](https://github.com/Headmaster218/MoE4All/blob/main/docs/README.md)
+and the
+[MoE4All wiki](https://github.com/Headmaster218/MoE4All/blob/main/infr-fork-wiki/README.md).
 
 ## Current limitations
 

--- a/README_EN.md
+++ b/README_EN.md
@@ -24,33 +24,33 @@ bilingual wizard, and choose automatic configuration.
 
 Qwen3.8-Flash-Next now generates stable, coherent output through MoE4All on a
 consumer **AMD Radeon RX 7900 XTX**, including correct answers to simple math
-and reasoning questions. The first run used Windows 11, a Q2 quantization, and
-approximately **40 GB of system memory**.
+and reasoning questions. Both Q2_K_XL and IQ4_XS quantizations have been tested
+on Windows 11 with SSD paging under a **40 GiB bounded-RAM** budget.
 
 The `qwen4exp` text path now covers the released model's four-stream
 hyper-connections, gated DeltaNet/full-attention layer mix, SSD-backed PLE,
 paged MoE, and **QSA sparse attention**. QSA maintains a separate F16 index-key
 cache, selects complete history blocks, and preserves the incomplete causal
-tail, removing the first implementation's temporary roughly 2K context limit.
+tail for long-context inference. The main K/V cache supports Q8_0, while the
+QSA index-key cache remains F16 and is budgeted and allocated independently.
 
-The first four rows below are representative values from three short runs. The
-last two are the newly completed QSA path checks. Their `tg1` workload verifies
-that both real and synthetic KV cross the QSA activation boundary; it is not a
-final long-context throughput measurement.
+The table below was measured on an RX 7900 XTX with Vulkan0, Q8 K/V, and a
+40 GiB bounded-RAM budget. Decode uses `tg128`, prefill uses `pp1024`, and the
+ubatch is 1024. Depths 128K and 250K use synthetic depth to construct the real
+KV length. Every entry is a three-run average and reports `kv_q8=true` and
+`kv_layout=q8_0`.
 
-| Test | Representative result | Three-run range |
-|---|---:|---:|
-| Decode at context 0, tg16 | **43.5 tok/s** | 42.6-44.9 tok/s |
-| Prefill at context 0, pp32 | **46.6 tok/s** | 46.2-47.1 tok/s |
-| Decode at context 1024, tg16 | **41.9 tok/s** | 41.4-42.7 tok/s |
-| Incremental prefill at context 1024, pp32 | **42.6 tok/s** | 42.1-43.3 tok/s |
-| QSA decode after real prefill to depth 2052, tg1 | **32.9 tok/s** | One path-validation run |
-| QSA decode after synthetic depth 4096, tg1 | **22.9 tok/s** | One path-validation run |
+| Context depth | Q2_K_XL decode | Q2_K_XL prefill | IQ4_XS decode | IQ4_XS prefill |
+|---:|---:|---:|---:|---:|
+| 0 | **29.45 tok/s** | **155.16 tok/s** | **16.85 tok/s** | **244.68 tok/s** |
+| 128K | **26.23 tok/s** | **170.44 tok/s** | **14.15 tok/s** | **250.55 tok/s** |
+| 250K | **22.82 tok/s** | **152.27 tok/s** | **15.26 tok/s** | **239.00 tok/s** |
 
-QSA currently uses a correctness-first exact block-selection implementation.
-Long-context kernels and end-to-end throughput still have room to improve, but
-the model architecture, cache allocation, and sparse-attention data path are
-now complete.
+Q2 and IQ4_XS both passed three-round API conversations while preserving a
+verification code, completing cross-turn arithmetic, and summarizing prior
+content. QSA uses radix top-k with exact score/index ordering, and batched
+QSA/PLE prefill is enabled. Decode remains sensitive to expert RAM/SSD coverage
+and has further optimization headroom.
 
 ## Start in three steps
 
@@ -129,8 +129,10 @@ capabilities; rows use different workloads and are not directly comparable.
 | Qwen3.6-35B-A3B prefill 4,096 after 250K synthetic depth | Q8 K/V | **477.9 tok/s** |
 | Qwen3.6-35B-A3B prefill 4,096 at depth 0 | Q8 K/V | **2,855.6 tok/s** |
 | Qwen3.5-122B-A10B decode at depth 0 | F16 K/V, 45 GiB bounded RAM, 3 repetitions | **23.2 tok/s** |
-| Qwen3.8-Flash-Next QSA decode after real depth 2052 | Q2, F16 K/V, 40 GiB bounded RAM, tg1 path check | **32.9 tok/s** |
-| Qwen3.8-Flash-Next QSA decode after synthetic depth 4096 | Q2, F16 K/V, 40 GiB bounded RAM, tg1 path check | **22.9 tok/s** |
+| Qwen3.8-Flash-Next Q2_K_XL decode after 250K synthetic depth | Q8 K/V, 40 GiB bounded RAM, tg128, 3-run average | **22.82 tok/s** |
+| Qwen3.8-Flash-Next Q2_K_XL prefill 1,024 after 250K | Q8 K/V, 40 GiB bounded RAM, 3-run average | **152.27 tok/s** |
+| Qwen3.8-Flash-Next IQ4_XS decode after 250K synthetic depth | Q8 K/V, 40 GiB bounded RAM, tg128, 3-run average | **15.26 tok/s** |
+| Qwen3.8-Flash-Next IQ4_XS prefill 1,024 after 250K | Q8 K/V, 40 GiB bounded RAM, 3-run average | **239.00 tok/s** |
 
 Full conditions and engineering history:
 

--- a/Start-INFR-Wizard.cmd
+++ b/Start-INFR-Wizard.cmd
@@ -1,8 +1,9 @@
 @echo off
 setlocal
+title MoE4All Launch Wizard
 powershell.exe -NoLogo -NoProfile -File "%~dp0scripts\infr-wizard.ps1" %*
-set "INFR_WIZARD_EXIT=%ERRORLEVEL%"
+set "MOE4ALL_WIZARD_EXIT=%ERRORLEVEL%"
 echo.
-if not "%INFR_WIZARD_EXIT%"=="0" echo INFR Wizard exited with code %INFR_WIZARD_EXIT%.
+if not "%MOE4ALL_WIZARD_EXIT%"=="0" echo MoE4All Wizard exited with code %MOE4ALL_WIZARD_EXIT%.
 pause
-exit /b %INFR_WIZARD_EXIT%
+exit /b %MOE4ALL_WIZARD_EXIT%

--- a/crates/infr-cli/src/main.rs
+++ b/crates/infr-cli/src/main.rs
@@ -734,11 +734,12 @@ fn cli_flag_layer(cmd: &Cmd) -> anyhow::Result<PartialConfig> {
         }
         Cmd::Bench { device, .. } => {
             device.overrides(&mut layer)?;
-            // Benchmarks decode a FIXED token count (llama-bench semantics): never stop at EOS — a
-            // model that emits EOS instantly on the dummy context would otherwise report fictional
-            // tok/s. `cmd_bench` used to `set_var("INFR_IGNORE_EOS", "1")` itself; as a flag-level
-            // override it wins over the file and the environment just as that overwrite did.
+            // Benchmarks decode a FIXED, deterministic token count (llama-bench semantics): greedy
+            // sampling with a fixed seed, and never stop at EOS. The four-prompt Vulkan harness
+            // relies on every A/B process taking the same generated-token path for each prompt.
             layer.sampling.ignore_eos = Some(true);
+            layer.sampling.temp = Some(0.0);
+            layer.sampling.seed = Some(Some(0x1_6e37));
         }
         Cmd::Pull { .. } | Cmd::Devices | Cmd::Multi { .. } | Cmd::Compare { .. } => {}
     }
@@ -2186,8 +2187,9 @@ fn run_chat(
 }
 
 /// Benchmark prefill (pp) or decode (tg) tok/s with the same -p/-n/-d/-r interface as
-/// `llama-bench`, so `infr bench` and `llama-bench` are directly comparable. Dummy tokens (timing
-/// is data-independent), `prefill_chunk` policy for the prefill batching (the engine's real path).
+/// `llama-bench`, so `infr bench` and `llama-bench` are directly comparable. Vulkan uses four
+/// stable math-prompt streams so exact-shape warmup does not preheat the identical MoE route;
+/// `prefill_chunk` policy remains the engine's real path.
 #[allow(clippy::too_many_arguments)]
 fn cmd_bench(
     model: &str,
@@ -2205,9 +2207,8 @@ fn cmd_bench(
     // (which `VulkanBackend::new_with` reads its device pick off since S5a), `-u` through
     // INFR_UBATCH, `-t` through RAYON_NUM_THREADS. So `--dev metal`/`--dev cpu` route here exactly
     // like a raw `INFR_DEV=metal`/`INFR_DEV=cpu` invocation.
-    // Bench also pins `sampling.ignore_eos` (see `cli_flag_layer`): benchmarks decode a FIXED token
-    // count (llama-bench semantics) and never stop at EOS — a model that emits EOS instantly on the
-    // dummy context would otherwise report fictional tok/s.
+    // Bench pins greedy sampling, its seed and `sampling.ignore_eos` (see `cli_flag_layer`): each
+    // A/B process follows the same generated route and decodes a FIXED token count.
     // -pg "P,G": a coding-agent turn (ingest P then generate G); throughput = (P+G)/time.
     let synthetic_depth = synthetic_depth.filter(|&d| d > 0);
     if synthetic_depth.is_some() && depth != 0 {
@@ -4850,13 +4851,26 @@ mod tests {
     }
 
     #[test]
-    fn bench_pins_ignore_eos_through_the_cli_layer() {
-        // What `cmd_bench`'s `set_var("INFR_IGNORE_EOS", "1")` used to do: a flag-level override,
-        // so it wins over the environment exactly as that overwrite did.
+    fn bench_pins_deterministic_sampling_through_the_cli_layer() {
+        // Bench owns the sampling path: these flag-level overrides beat environment/config values
+        // so repeated A/B processes follow the same generated-token route.
         let layer = cli_flag_layer(&bench_cmd()).unwrap();
         assert!(layer.is_path_set("sampling.ignore_eos"));
-        assert!(resolve_cfg(&[], layer, &[]).sampling.ignore_eos);
-        // …and `run` does NOT pin it.
+        assert!(layer.is_path_set("sampling.temp"));
+        assert!(layer.is_path_set("sampling.seed"));
+        let cfg = resolve_cfg(
+            &[
+                ("INFR_IGNORE_EOS", "0"),
+                ("INFR_TEMP", "0.8"),
+                ("INFR_SEED", "9"),
+            ],
+            layer,
+            &[],
+        );
+        assert!(cfg.sampling.ignore_eos);
+        assert_eq!(cfg.sampling.temp, 0.0);
+        assert_eq!(cfg.sampling.seed, Some(0x1_6e37));
+        // `run` does NOT pin benchmark sampling.
         let layer = cli_flag_layer(&Cmd::Run {
             model: "m".to_string(),
             message: None,

--- a/crates/infr-core/src/graph.rs
+++ b/crates/infr-core/src/graph.rs
@@ -428,6 +428,9 @@ pub enum Op {
         k_cache: TensorId,
         k_norm: TensorId,
         dst: TensorId,
+        /// Number of consecutive query rows. Row `r` sees
+        /// `kv_len - rows + r + 1` cached tokens.
+        rows: u32,
         kv_len: u32,
         n_head: u32,
         head_dim: u32,
@@ -451,6 +454,26 @@ pub enum Op {
         tail: u32,
         ratio: u32,
         row_elems: u32,
+    },
+    /// Batched Qwen3.8 QSA attention over row-specific selected blocks. Unlike
+    /// [`Op::QsaGather`], which materializes one compact K/V prefix for one query, this op reads
+    /// each row's chronological block-index slice directly and applies attention to that row's
+    /// selected complete blocks plus its own incomplete causal tail. `kv_len` is the visible
+    /// length of the final row; row `r` sees `kv_len - rows + r + 1` tokens.
+    QsaBatchAttention {
+        q: TensorId,
+        k_cache: TensorId,
+        v_cache: TensorId,
+        indices: TensorId,
+        dst: TensorId,
+        rows: u32,
+        kv_len: u32,
+        n_head: u32,
+        n_kv: u32,
+        head_dim: u32,
+        top_blocks: u32,
+        ratio: u32,
+        scale: f32,
     },
     /// Scaled-dot-product attention. `q` is `rows × n_head × head_dim`; `k_cache`/`v_cache` hold
     /// `kv_len` rows of `n_kv × head_dim`. GQA when `n_head > n_kv`. `dst` is `rows × n_head ×
@@ -1276,6 +1299,7 @@ impl Op {
             Op::Dsv4Gather { .. } => "Dsv4Gather",
             Op::QsaIndexer { .. } => "QsaIndexer",
             Op::QsaGather { .. } => "QsaGather",
+            Op::QsaBatchAttention { .. } => "QsaBatchAttention",
             Op::Attention { .. } => "Attention",
             Op::Mla { .. } => "Mla",
             Op::LightningIndexer { .. } => "LightningIndexer",
@@ -1421,6 +1445,14 @@ impl Op {
                 v_dst,
                 ..
             } => (vec![k_cache, v_cache, indices], vec![k_dst, v_dst]),
+            Op::QsaBatchAttention {
+                q,
+                k_cache,
+                v_cache,
+                indices,
+                dst,
+                ..
+            } => (vec![q, k_cache, v_cache, indices], vec![dst]),
             Op::Attention {
                 q,
                 k_cache,
@@ -1672,6 +1704,12 @@ impl Graph {
                         set.insert(*k_cache);
                     }
                     Op::QsaGather {
+                        k_cache, v_cache, ..
+                    } => {
+                        set.insert(*k_cache);
+                        set.insert(*v_cache);
+                    }
+                    Op::QsaBatchAttention {
                         k_cache, v_cache, ..
                     } => {
                         set.insert(*k_cache);

--- a/crates/infr-cpu/src/lib.rs
+++ b/crates/infr-cpu/src/lib.rs
@@ -2153,6 +2153,7 @@ impl Backend for CpuBackend {
                     k_cache,
                     k_norm,
                     dst,
+                    rows,
                     kv_len,
                     n_head,
                     head_dim,
@@ -2163,7 +2164,8 @@ impl Backend for CpuBackend {
                     eps,
                     scale,
                 } => {
-                    let (kv_len, nh, hd, top_blocks, ratio, rope_dim) = (
+                    let (rows, kv_len, nh, hd, top_blocks, ratio, rope_dim) = (
+                        rows as usize,
                         kv_len as usize,
                         n_head as usize,
                         head_dim as usize,
@@ -2171,7 +2173,7 @@ impl Backend for CpuBackend {
                         ratio as usize,
                         rope_dim as usize,
                     );
-                    let blocks = kv_len / ratio;
+                    let max_blocks = kv_len / ratio;
                     let q = &vals[q.0 as usize];
                     let norm = &vals[k_norm.0 as usize];
                     let cache = cpu_buf(
@@ -2180,51 +2182,65 @@ impl Backend for CpuBackend {
                             .expect("cpu backend: unbound QSA index-key cache"),
                     )
                     .read();
-                    let raw = dequant_cache_prefix(&cache, DType::F16, blocks * ratio * hd);
-                    let mut scores = vec![0.0f32; blocks];
+                    let raw = dequant_cache_prefix(&cache, DType::F16, max_blocks * ratio * hd);
+                    let mut scores = vec![0.0f32; rows * max_blocks];
+                    let mut selected_rows = vec![0.0f32; rows * top_blocks];
                     let mut key = vec![0.0f32; hd];
-                    for block in 0..blocks {
-                        key.fill(0.0);
-                        for r in 0..ratio {
-                            let src = (block * ratio + r) * hd;
-                            for d in 0..hd {
-                                key[d] += raw[src + d] / ratio as f32;
+                    for row in 0..rows {
+                        let visible = kv_len - rows + row + 1;
+                        let blocks = visible / ratio;
+                        for block in 0..blocks {
+                            key.fill(0.0);
+                            for rr in 0..ratio {
+                                let src = (block * ratio + rr) * hd;
+                                for d in 0..hd {
+                                    key[d] += raw[src + d] / ratio as f32;
+                                }
                             }
+                            for v in &mut key {
+                                *v = half::f16::from_f32(*v).to_f32();
+                            }
+                            let inv = (key.iter().map(|v| v * v).sum::<f32>() / hd as f32 + eps)
+                                .sqrt()
+                                .recip();
+                            for d in 0..hd {
+                                key[d] *= inv * norm[d];
+                            }
+                            let pos = (block * ratio) as f32;
+                            for pair in 0..rope_dim / 2 {
+                                let d = pair * 2;
+                                let angle =
+                                    pos * theta.powf(-((2 * pair) as f32) / rope_dim as f32);
+                                let (sin, cos) = angle.sin_cos();
+                                let (a, b) = (key[d], key[d + 1]);
+                                key[d] = a * cos - b * sin;
+                                key[d + 1] = a * sin + b * cos;
+                            }
+                            let mut score = 0.0f32;
+                            let qb = row * nh * hd;
+                            for h in 0..nh {
+                                score +=
+                                    dot(&q[qb + h * hd..qb + (h + 1) * hd], &key).max(0.0) * scale;
+                            }
+                            scores[row * max_blocks + block] = score;
                         }
-                        for v in &mut key {
-                            *v = half::f16::from_f32(*v).to_f32();
+                        let selected = top_blocks.min(blocks);
+                        let row_scores = &scores[row * max_blocks..(row + 1) * max_blocks];
+                        let mut order: Vec<usize> = (0..blocks).collect();
+                        if selected > 0 {
+                            order.select_nth_unstable_by(selected - 1, |&a, &b| {
+                                row_scores[b]
+                                    .total_cmp(&row_scores[a])
+                                    .then_with(|| a.cmp(&b))
+                            });
                         }
-                        let inv = (key.iter().map(|v| v * v).sum::<f32>() / hd as f32 + eps)
-                            .sqrt()
-                            .recip();
-                        for d in 0..hd {
-                            key[d] *= inv * norm[d];
+                        order.truncate(selected);
+                        order.sort_unstable();
+                        for (slot, block) in order.into_iter().enumerate() {
+                            selected_rows[row * top_blocks + slot] = block as f32;
                         }
-                        let pos = (block * ratio) as f32;
-                        for pair in 0..rope_dim / 2 {
-                            let d = pair * 2;
-                            let angle = pos * theta.powf(-((2 * pair) as f32) / rope_dim as f32);
-                            let (sin, cos) = angle.sin_cos();
-                            let (a, b) = (key[d], key[d + 1]);
-                            key[d] = a * cos - b * sin;
-                            key[d + 1] = a * sin + b * cos;
-                        }
-                        let mut score = 0.0f32;
-                        for h in 0..nh {
-                            score += dot(&q[h * hd..(h + 1) * hd], &key).max(0.0) * scale;
-                        }
-                        scores[block] = score;
                     }
-                    let selected = top_blocks.min(blocks);
-                    let mut order: Vec<usize> = (0..blocks).collect();
-                    if selected > 0 {
-                        order.select_nth_unstable_by(selected - 1, |&a, &b| {
-                            scores[b].total_cmp(&scores[a]).then_with(|| a.cmp(&b))
-                        });
-                    }
-                    order.truncate(selected);
-                    order.sort_unstable();
-                    vals[dst.0 as usize] = order.into_iter().map(|i| i as f32).collect();
+                    vals[dst.0 as usize] = selected_rows;
                 }
                 Op::QsaGather {
                     k_cache,
@@ -2278,6 +2294,85 @@ impl Backend for CpuBackend {
                     }
                     vals[k_dst.0 as usize] = ko;
                     vals[v_dst.0 as usize] = vo;
+                }
+                Op::QsaBatchAttention {
+                    q,
+                    k_cache,
+                    v_cache,
+                    indices,
+                    dst,
+                    rows,
+                    kv_len,
+                    n_head,
+                    n_kv,
+                    head_dim,
+                    top_blocks,
+                    ratio,
+                    scale,
+                } => {
+                    let (rows, kv_len, nh, nkv, hd, top_blocks, ratio) = (
+                        rows as usize,
+                        kv_len as usize,
+                        n_head as usize,
+                        n_kv as usize,
+                        head_dim as usize,
+                        top_blocks as usize,
+                        ratio as usize,
+                    );
+                    let qs = &vals[q.0 as usize];
+                    let ids = &vals[indices.0 as usize];
+                    let read_cache = |id: TensorId| {
+                        let b = bindings
+                            .get(id)
+                            .expect("cpu backend: unbound QSA K/V cache");
+                        dequant_cache_prefix(
+                            &cpu_buf(b).read(),
+                            g.desc(id).dtype,
+                            kv_len * nkv * hd,
+                        )
+                    };
+                    let ks = read_cache(k_cache);
+                    let vs = read_cache(v_cache);
+                    let group = nh / nkv;
+                    let mut out = vec![0.0f32; rows * nh * hd];
+                    self.pool().for_chunks_mut(&mut out, hd, 1, &|rh, out_row| {
+                        let row = rh / nh;
+                        let head = rh % nh;
+                        let kv_head = head / group;
+                        let visible = kv_len - rows + row + 1;
+                        let complete = visible / ratio;
+                        let tail = visible % ratio;
+                        let selected = top_blocks.min(complete);
+                        let qbase = (row * nh + head) * hd;
+                        let qrow = &qs[qbase..qbase + hd];
+                        let mut source_rows = Vec::with_capacity(selected * ratio + tail);
+                        for slot in 0..selected {
+                            let block = ids[row * top_blocks + slot] as usize;
+                            source_rows.extend(block * ratio..(block + 1) * ratio);
+                        }
+                        source_rows.extend(complete * ratio..complete * ratio + tail);
+
+                        let mut logits = Vec::with_capacity(source_rows.len());
+                        let mut max_logit = f32::NEG_INFINITY;
+                        for &src_row in &source_rows {
+                            let kb = (src_row * nkv + kv_head) * hd;
+                            let logit = dot(qrow, &ks[kb..kb + hd]) * scale;
+                            logits.push(logit);
+                            max_logit = max_logit.max(logit);
+                        }
+                        let denom = logits
+                            .iter()
+                            .map(|&logit| (logit - max_logit).exp())
+                            .sum::<f32>();
+                        for (&src_row, &logit) in source_rows.iter().zip(&logits) {
+                            let p = (logit - max_logit).exp() / denom;
+                            let vb = (src_row * nkv + kv_head) * hd;
+                            for (dst, &value) in out_row.iter_mut().zip(&vs[vb..vb + hd]) {
+                                *dst = value.mul_add(p, *dst);
+                            }
+                        }
+                    });
+                    vals[dst.0 as usize] = out;
                 }
                 Op::Attention {
                     q,

--- a/crates/infr-llama/src/seam/mod.rs
+++ b/crates/infr-llama/src/seam/mod.rs
@@ -1224,17 +1224,27 @@ pub(crate) fn kv_row_align_ok(cfg: &Config) -> bool {
 /// what keeps the estimate and the allocation in agreement: a format the runner will refuse to
 /// build can never be pinned and priced in the first place.
 pub(crate) fn kv_q8_layout_ok(cfg: &Config) -> bool {
-    !cfg.deepseek2 && !cfg.deepseek4 && !cfg.bailingmoe3 && !cfg.qwen4exp && kv_row_align_ok(cfg)
+    !cfg.deepseek2 && !cfg.deepseek4 && !cfg.bailingmoe3 && kv_row_align_ok(cfg)
 }
 
 /// Resolve the KV dtype the Vulkan runner will allocate for one side, for placement accounting.
 /// This mirrors `runner.rs`'s capability gates closely enough that an explicit Q8/F16 choice is
 /// priced exactly instead of the MoE planner treating every non-auto choice as f16.
 fn vulkan_kv_fmt_for_budget(cfg: &Config, ec: &EngineConfig, requested: Option<DType>) -> DType {
-    if cfg.deepseek2 || cfg.deepseek4 || cfg.bailingmoe3 || cfg.qwen4exp {
+    if cfg.deepseek2 || cfg.deepseek4 || cfg.bailingmoe3 {
         return DType::F16;
     }
     let block_aligned = kv_row_align_ok(cfg);
+    // Qwen3.8's QSA gather/attention reads the ordinary K/V cache in F16 or planar Q8_0. Its
+    // separate raw index-key cache remains F16 and is priced by `qsa_cache_bytes` below.
+    if cfg.qwen4exp {
+        return match requested {
+            Some(DType::Q8_0) if block_aligned => DType::Q8_0,
+            Some(DType::F16) => DType::F16,
+            _ if (ec.kv.force_q8 || kv_auto_q8()) && block_aligned => DType::Q8_0,
+            _ => DType::F16,
+        };
+    }
     let turbo_aligned = (0..cfg.n_layer).all(|l| cfg.layer_head_dim(l).is_multiple_of(128));
     match requested {
         Some(dt @ (DType::Turbo2 | DType::Turbo3 | DType::Turbo4)) if turbo_aligned => dt,
@@ -4851,6 +4861,59 @@ mod seam_helper_tests {
             .map(|l| super::qsa_cache_bytes(&cfg, l, ctx))
             .sum();
         assert_eq!(total, 768 * 1024 * 1024);
+    }
+
+    #[test]
+    fn qwen38_q8_prices_only_the_main_kv_cache_as_q8() {
+        let recurrent_layers: Vec<bool> =
+            (0usize..48).map(|l| !(l + 1).is_multiple_of(4)).collect();
+        let cfg = Config {
+            qwen4exp: true,
+            n_layer: 48,
+            full_attn_interval: 4,
+            recurrent_layers,
+            n_kv: 2,
+            head_dim: 256,
+            indexer_head_size: 128,
+            ssm_d_conv: 4,
+            ssm_d_state: 128,
+            ssm_d_inner: 2048,
+            ssm_n_group: 8,
+            ssm_dt_rank: 16,
+            ..Default::default()
+        };
+        let ec = EngineConfig {
+            kv: infr_core::config::KvCfg {
+                type_k: Some(DType::Q8_0),
+                type_k_specified: true,
+                type_v: Some(DType::Q8_0),
+                type_v_specified: true,
+                ..Default::default()
+            },
+            ..Default::default()
+        };
+        assert!(super::kv_row_align_ok(&cfg));
+        assert!(super::kv_q8_layout_ok(&cfg));
+        assert_eq!(
+            super::vulkan_kv_fmt_for_budget(&cfg, &ec, ec.kv.type_k),
+            DType::Q8_0
+        );
+
+        let ctx = 262_144usize;
+        let f16 = super::kv_bytes_estimate_fmt(&cfg, ctx, false, 1024, DType::F16, DType::F16);
+        let q8 = super::kv_bytes_estimate_fmt(&cfg, ctx, false, 1024, DType::Q8_0, DType::Q8_0);
+        let elems_per_side = ctx * cfg.n_kv * cfg.head_dim;
+        let saved_per_full_layer = 2
+            * (super::kv_side_bytes(DType::F16, elems_per_side)
+                - super::kv_side_bytes(DType::Q8_0, elems_per_side));
+        assert_eq!(f16 - q8, (12 * saved_per_full_layer) as u64);
+        assert_eq!(
+            (0..cfg.n_layer)
+                .map(|l| super::qsa_cache_bytes(&cfg, l, ctx))
+                .sum::<usize>(),
+            768 * 1024 * 1024,
+            "the independent F16 QSA index cache is unchanged"
+        );
     }
 
     #[test]

--- a/crates/infr-llama/src/seam/mod.rs
+++ b/crates/infr-llama/src/seam/mod.rs
@@ -667,15 +667,10 @@ pub(crate) fn dense_act_reserve_at(
     want_ctx: usize,
     ubatch: usize,
 ) -> u64 {
-    // Prefill GEMM outputs pad rows to 64 (see the Vulkan adapter's `alloc_scratch`).
-    // Qwen3.8 v1 deliberately executes one token at a time: the PLE host gather is overlapped
-    // with layer 0 and the four-stream residual is carried across that split. Pricing a 1024-row
-    // graph that is never built would withhold many GiB from its expert cache.
-    let rows = if cfg.qwen4exp {
-        1
-    } else {
-        ubatch.min(want_ctx).max(1).next_multiple_of(64) as u64
-    };
+    // Prefill GEMM outputs pad rows to 64 (see the Vulkan adapter's `alloc_scratch`). Qwen3.8 now
+    // builds the same ubatch-height graph as the other supported architectures, including its
+    // four-stream residual, PLE and row-aware QSA scratch, so it must reserve the real row count.
+    let rows = ubatch.min(want_ctx).max(1).next_multiple_of(64) as u64;
     // Only Op::Attention uses the pooled score/PV scratch below. Op::Mla scans compressed KV and
     // accumulates softmax/value inside its dedicated kernel, while recurrent mixers have no
     // context attention at all. Keep n_layer == 0 conservative for geometry-only configs/tests.
@@ -760,7 +755,16 @@ pub(crate) fn dense_act_reserve_at(
     };
     let per_row =
         (12 * cfg.n_ff + 96 * cfg.n_embd + attn_pv + attn_s + moe + deltanet + qwen4_hc) as u64;
-    rows * per_row * ACT_RESERVE_PAD.0 / ACT_RESERVE_PAD.1
+    let row_reserve = rows * per_row * ACT_RESERVE_PAD.0 / ACT_RESERVE_PAD.1;
+    // Qwen3.8 keeps its scalar decode graph live while a separately compiled batched-prefill
+    // graph owns the row-scaled pools above. Two real runs at d4096 measured the fixed intercept
+    // at 54.6 MiB (64 rows: 143.6 MiB peak; 128 rows: 232.7 MiB), so round it up to 64 MiB.
+    // This is a fixed plan-overlap cost, not another per-row multiplier.
+    row_reserve.saturating_add(if cfg.qwen4exp {
+        QWEN4_PLAN_OVERLAP_RESERVE
+    } else {
+        0
+    })
 }
 
 /// Activation bytes LAYER-MAJOR prefill holds ON TOP of [`dense_act_reserve_at`]: the residual
@@ -853,6 +857,7 @@ pub(crate) fn layer_major_prefill(
 /// is still the largest — which is the argument for deriving these bytes from the graph the runner
 /// already builds rather than re-deriving them here (backlog B8).
 const ACT_RESERVE_PAD: (u64, u64) = (3, 2);
+const QWEN4_PLAN_OVERLAP_RESERVE: u64 = 64 * 1024 * 1024;
 
 /// Batched-prefill micro-batch: rows per prefill chunk (`device.ubatch` / `INFR_UBATCH`, default
 /// 1024 — but see [`default_ubatch_rows`] for the INTEGRATED-GPU default). ONE reader funnel — the
@@ -4846,6 +4851,43 @@ mod seam_helper_tests {
             .map(|l| super::qsa_cache_bytes(&cfg, l, ctx))
             .sum();
         assert_eq!(total, 768 * 1024 * 1024);
+    }
+
+    #[test]
+    fn qwen38_activation_reserve_tracks_the_real_prefill_batch() {
+        let cfg = Config {
+            qwen4exp: true,
+            n_layer: 48,
+            n_head: 24,
+            n_embd: 2560,
+            n_ff: 640,
+            head_dim: 256,
+            hc_mult: 4,
+            hc_low_rank: 320,
+            ssm_d_inner: 6144,
+            ssm_n_group: 16,
+            ssm_dt_rank: 48,
+            ssm_d_state: 128,
+            moe: Some(crate::MoeConfig {
+                n_expert: 512,
+                n_used: 10,
+                n_ff_exp: 640,
+                scale: 1.0,
+                gating: infr_core::graph::MoeGating::Sigmoid,
+                norm_w: true,
+                weight_before: false,
+                n_expert_groups: 0,
+                n_expert_groups_used: 0,
+            }),
+            ..Default::default()
+        };
+        let half = super::dense_act_reserve_at(&cfg, &conservative_caps(), 4096, 512);
+        let full = super::dense_act_reserve_at(&cfg, &conservative_caps(), 4096, 1024);
+        assert_eq!(
+            full - super::QWEN4_PLAN_OVERLAP_RESERVE,
+            2 * (half - super::QWEN4_PLAN_OVERLAP_RESERVE),
+            "only the row-scaled part doubles; the retained decode plan is fixed"
+        );
     }
 
     fn deepseek4_cache_config() -> Config {

--- a/crates/infr-llama/src/seam/mod.rs
+++ b/crates/infr-llama/src/seam/mod.rs
@@ -746,10 +746,12 @@ pub(crate) fn dense_act_reserve_at(
     } else {
         0
     };
-    // Qwen3.8's two wide ping-pong residuals, grouped-norm/gate scratch and PLE key/query/gated/
-    // conv rows. The generic n_embd umbrella does not cover hc*n_embd tensors.
+    // Qwen3.8's caller-owned wide residual; qwen_alt/normed/gate scratch; and PLE
+    // key/query/gated/conv rows are eight f32 `[rows, hc*n_embd]` buffers in total. The low-rank
+    // projection and per-stream injection are f32 too. The generic n_embd umbrella cannot absorb
+    // these hc-wide tensors.
     let qwen4_hc = if cfg.qwen4exp {
-        8 * cfg.hc_mult * cfg.n_embd + 3 * cfg.hc_low_rank
+        32 * cfg.hc_mult * cfg.n_embd + 4 * cfg.hc_low_rank + 4 * cfg.hc_mult
     } else {
         0
     };

--- a/crates/infr-llama/src/seam/model.rs
+++ b/crates/infr-llama/src/seam/model.rs
@@ -38,6 +38,17 @@ pub struct BenchPlacement {
     pub submit_cap: usize,
 }
 
+/// Four stable, similarly sized math prompts for Vulkan performance A/Bs. Prompt 0 warms the exact
+/// graph shape; measured repetitions use prompts 1, 2 and 3 in order. This keeps shader/pipeline
+/// creation out of the timed window without preloading the expert cache with the exact token route
+/// that is about to be measured.
+const VULKAN_BENCH_PROMPTS: [&str; 4] = [
+    "Solve x squared minus five x plus six equals zero and explain each algebraic step.",
+    "Differentiate x cubed minus four x squared plus seven and explain each calculus step.",
+    "Compute the sum of the first fifty odd integers and justify the result carefully.",
+    "Prove that the square root of two is irrational by using a contradiction argument.",
+];
+
 /// A **GPU-free** model for the CPU reference backend. Holds only what the agnostic CPU compute
 /// graph needs — the parsed [`Config`], the host f32 token embeddings (for the gather + tied lm
 /// head), the tokenizer, and the gemma4 E2B per-layer-embd tensors. No `VulkanBackend`, no VRAM,
@@ -1354,10 +1365,23 @@ impl SeamModel {
         // KV must fit it even when the measured shape is tiny (pp2 with +8 sized the cache to 10
         // and the warmup itself overflowed it).
         let want = measured_depth + p_eff.max(1) + g_eff + 16;
-        let dummy = |n: usize| -> Vec<u32> { (0..n.max(1)).map(|i| (i % 100) as u32).collect() };
+        let prompt_banks: Vec<Vec<u32>> = VULKAN_BENCH_PROMPTS
+            .iter()
+            .map(|prompt| self.encode(prompt))
+            .collect::<Result<_>>()?;
+        if prompt_banks.iter().any(Vec::is_empty) {
+            return Err(anyhow!(
+                "Vulkan benchmark prompt tokenized to an empty sequence"
+            ));
+        }
+        let prompt_tokens = |n: usize, prompt_stream: usize| -> Vec<u32> {
+            let bank = &prompt_banks[prompt_stream % prompt_banks.len()];
+            (0..n.max(1)).map(|i| bank[i % bank.len()]).collect()
+        };
         let mut state: Option<crate::seam::SeamKv> = None;
         let run = |prompt_len: usize,
                    gen: usize,
+                   prompt_stream: usize,
                    state: &mut Option<crate::seam::SeamKv>|
          -> Result<crate::GenStats> {
             let (_, stats) = crate::seam::generate_dense_vulkan_session(
@@ -1367,7 +1391,7 @@ impl SeamModel {
                 &self.ecfg,
                 self.embd(),
                 self.per_layer_embd.as_ref(),
-                &dummy(prompt_len),
+                &prompt_tokens(prompt_len, prompt_stream),
                 gen,
                 |_| {},
                 state,
@@ -1389,75 +1413,79 @@ impl SeamModel {
         // from the exit aggregate.
         let unprofiled = |prompt_len: usize,
                           gen: usize,
+                          prompt_stream: usize,
                           state: &mut Option<crate::seam::SeamKv>|
          -> Result<crate::GenStats> {
-            crate::with_profiling_suppressed(|| run(prompt_len, gen, state))
+            crate::with_profiling_suppressed(|| run(prompt_len, gen, prompt_stream, state))
         };
-        let seed_synthetic = |state: &mut Option<crate::seam::SeamKv>| -> Result<()> {
-            let Some(st) = state.as_mut() else {
-                return Err(anyhow!(
+        let seed_synthetic =
+            |prompt_stream: usize, state: &mut Option<crate::seam::SeamKv>| -> Result<()> {
+                let Some(st) = state.as_mut() else {
+                    return Err(anyhow!(
                     "synthetic depth requested before the Vulkan benchmark session was initialized"
                 ));
+                };
+                if let Some(depth) = synthetic_depth {
+                    st.set_synthetic_cached(&vk, &self.cfg, prompt_tokens(depth, prompt_stream))?;
+                }
+                Ok(())
             };
-            if let Some(depth) = synthetic_depth {
-                st.set_synthetic_cached(&vk, &self.cfg, dummy(depth))?;
-            }
-            Ok(())
-        };
-        // ONE rep, exactly as measured: reset the KV, warm it to `depth` (untimed), time the
-        // metric, return it as tokens/sec. A closure so the discarded warm rep below and the
-        // measured reps run BYTE-IDENTICAL code — a warm rep that differs from a timed one in any
-        // way is not a warmup, it is a second measurement of something else.
-        let one_rep = |state: &mut Option<crate::seam::SeamKv>| -> Result<f64> {
-            if let Some(st) = state.as_mut() {
-                st.reset();
-            }
-            if synthetic_depth.is_some() {
-                seed_synthetic(state)?;
-            } else if depth > 0 {
-                // `depth + 1`, for the SAME reason the timed prefill below adds one: at `gen == 0`
-                // the decode loop breaks before feeding the frontier token, so a warm of `n` tokens
-                // materializes only `n - 1` KV rows and records exactly those as resident (see
-                // `resident_after_gen` — it deliberately stopped recording un-written rows, because
-                // the next turn would otherwise attend a stale/zero row).
-                //
-                // Warming with a bare `depth` therefore left the cache one row SHORT, and the timed
-                // run silently absorbed that row: `pp4 @ d4096` batch-prefilled positions
-                // `depth-1 ..= depth+4` — five rows — while still dividing by `n_prompt = 4`. Shape
-                // profiling shows it plainly (`mrow_streamed:m5:...` where it must be `m4`), and it
-                // under-reported this shape by ~20% against the pre-`a8b1809` numbers even though
-                // per-row throughput had IMPROVED. Feeding one extra token here leaves exactly
-                // `depth` rows resident, so the timed window holds precisely the work it reports —
-                // llama-bench's `-d` semantics.
-                unprofiled(depth + 1, 0, state)?; // warm the cache to `depth` (untimed)
-            }
-            if let Some((p, g)) = pg {
-                // coding-agent turn: prompt ingest + reply generation timed together.
-                let s = run(measured_depth + p, g, state)?;
-                Ok((p + g) as f64 / (s.prompt_secs + s.decode_secs).max(1e-9))
-            } else if n_gen > 0 {
-                // decode at depth: 1-token suffix feeds the loop, the timed part is the decode.
-                let s = run(measured_depth + 1, n_gen, state)?;
-                Ok(n_gen as f64 / s.decode_secs.max(1e-9))
-            } else {
-                // +1: the suffix's LAST token is the decode feed and is never processed at
-                // gen=0, and a suffix of <= 2 skips batched prefill entirely — so `depth + N`
-                // measured N-1 batched rows (and pp2 measured nothing, reporting the 1e-9
-                // floor). With +1, exactly N rows batch-prefill (positions depth..depth+N) and
-                // prompt_secs covers precisely them — llama-bench's -p N semantics.
-                let s = run(measured_depth + n_prompt + 1, 0, state)?;
-                Ok(n_prompt as f64 / s.prompt_secs.max(1e-9))
-            }
-        };
+        // ONE rep at one prompt stream: reset the KV, warm it to `depth` (untimed), time the metric,
+        // return it as tokens/sec. The discarded warm rep and measured reps run the same graph
+        // shape and code; only their stable prompt stream differs so MoE residency is not replayed.
+        let one_rep =
+            |prompt_stream: usize, state: &mut Option<crate::seam::SeamKv>| -> Result<f64> {
+                if let Some(st) = state.as_mut() {
+                    st.reset();
+                }
+                if synthetic_depth.is_some() {
+                    seed_synthetic(prompt_stream, state)?;
+                } else if depth > 0 {
+                    // `depth + 1`, for the SAME reason the timed prefill below adds one: at `gen == 0`
+                    // the decode loop breaks before feeding the frontier token, so a warm of `n` tokens
+                    // materializes only `n - 1` KV rows and records exactly those as resident (see
+                    // `resident_after_gen` — it deliberately stopped recording un-written rows, because
+                    // the next turn would otherwise attend a stale/zero row).
+                    //
+                    // Warming with a bare `depth` therefore left the cache one row SHORT, and the timed
+                    // run silently absorbed that row: `pp4 @ d4096` batch-prefilled positions
+                    // `depth-1 ..= depth+4` — five rows — while still dividing by `n_prompt = 4`. Shape
+                    // profiling shows it plainly (`mrow_streamed:m5:...` where it must be `m4`), and it
+                    // under-reported this shape by ~20% against the pre-`a8b1809` numbers even though
+                    // per-row throughput had IMPROVED. Feeding one extra token here leaves exactly
+                    // `depth` rows resident, so the timed window holds precisely the work it reports —
+                    // llama-bench's `-d` semantics.
+                    unprofiled(depth + 1, 0, prompt_stream, state)?; // warm to `depth` (untimed)
+                }
+                if let Some((p, g)) = pg {
+                    // coding-agent turn: prompt ingest + reply generation timed together.
+                    let s = run(measured_depth + p, g, prompt_stream, state)?;
+                    Ok((p + g) as f64 / (s.prompt_secs + s.decode_secs).max(1e-9))
+                } else if n_gen > 0 {
+                    // decode at depth: 1-token suffix feeds the loop, the timed part is the decode.
+                    let s = run(measured_depth + 1, n_gen, prompt_stream, state)?;
+                    Ok(n_gen as f64 / s.decode_secs.max(1e-9))
+                } else {
+                    // +1: the suffix's LAST token is the decode feed and is never processed at
+                    // gen=0, and a suffix of <= 2 skips batched prefill entirely — so `depth + N`
+                    // measured N-1 batched rows (and pp2 measured nothing, reporting the 1e-9
+                    // floor). With +1, exactly N rows batch-prefill (positions depth..depth+N) and
+                    // prompt_secs covers precisely them — llama-bench's -p N semantics.
+                    let s = run(measured_depth + n_prompt + 1, 0, prompt_stream, state)?;
+                    Ok(n_prompt as f64 / s.prompt_secs.max(1e-9))
+                }
+            };
         // Untimed warmup. Synthetic-depth mode uses a no-op one-token call to upload weights and
         // allocate zeroed KV without first writing a short real prefix into rows 0...
         if synthetic_depth.is_some() {
-            unprofiled(1, 0, &mut state)?;
+            unprofiled(1, 0, 0, &mut state)?;
         } else {
             // Real-depth mode preserves the historical generic warmup.
-            unprofiled(8, 2, &mut state)?;
+            unprofiled(8, 2, 0, &mut state)?;
         }
-        // Untimed warm rep AT THE MEASURED SHAPE, discarded (backlog B6/B16). The (8, 2) turn
+        // Untimed warm rep AT THE MEASURED SHAPE on prompt 0, discarded (backlog B6/B16). Measured
+        // reps use prompts 1..=3: pipelines/scratch are hot without replaying an identical expert
+        // route. The (8, 2) turn
         // above does NOT cover the shape being timed — it prefills 7 rows and decodes 2 — so the
         // first TIMED rep was paying that shape's one-time costs (its pipeline variants, its
         // first-touch scratch pools) inside the measured window, and `avg_ts` averaged them in.
@@ -1474,11 +1502,11 @@ impl SeamModel {
         // This is what `bench_vulkan`'s doc always claimed to do, and llama-bench does the same
         // (a discarded warmup iteration per shape). It removes a cold-start cost from the
         // average; it does not make any kernel faster.
-        crate::with_profiling_suppressed(|| one_rep(&mut state))?;
+        crate::with_profiling_suppressed(|| one_rep(0, &mut state))?;
         infr_prof_rt::gpu_reset();
         let mut samples = Vec::with_capacity(reps);
-        for _ in 0..reps.max(1) {
-            samples.push(one_rep(&mut state)?);
+        for rep in 0..reps.max(1) {
+            samples.push(one_rep(1 + rep % 3, &mut state)?);
         }
         // Read the placement AFTER the reps: the pins are set by the binder on the first load, and
         // the submit cap can only have moved during the runs. `bench_vulkan` holds no

--- a/crates/infr-llama/src/seam/ple.rs
+++ b/crates/infr-llama/src/seam/ple.rs
@@ -11,7 +11,9 @@ use std::sync::mpsc::{self, Receiver, SyncSender};
 const TABLE_NAME: &str = "per_layer_token_embd.weight";
 
 struct Job {
-    context: Vec<u32>,
+    tokens: Vec<u32>,
+    start: usize,
+    rows: usize,
     reply: SyncSender<Result<Vec<f32>>>,
 }
 
@@ -105,7 +107,9 @@ impl PleWorker {
             .name("infr-qwen4-ple".into())
             .spawn(move || {
                 while let Ok(job) = rx.recv() {
-                    let _ = job.reply.send(state.gather(&job.context));
+                    let _ = job
+                        .reply
+                        .send(state.gather_range(&job.tokens, job.start, job.rows));
                 }
             })
             .context("spawn qwen4exp PLE worker")?;
@@ -115,61 +119,96 @@ impl PleWorker {
     /// Start the SSD/mmap gather before layer 0 is submitted. Only the current token and at most
     /// `ngram-1` predecessors cross the channel.
     pub(super) fn submit(&self, tokens: &[u32], pos: usize, ngram: usize) -> Result<PleTicket> {
-        let begin = pos.saturating_sub(ngram.saturating_sub(1));
-        let context = tokens
-            .get(begin..=pos)
-            .with_context(|| {
-                format!(
-                    "PLE token position {pos} outside stream of {}",
-                    tokens.len()
-                )
-            })?
-            .to_vec();
+        self.submit_range(tokens, pos, 1, ngram)
+    }
+
+    /// Gather a consecutive known-prompt range in token order. Only the range and its at most
+    /// `ngram-1` predecessors cross the worker channel.
+    pub(super) fn submit_range(
+        &self,
+        tokens: &[u32],
+        start: usize,
+        rows: usize,
+        ngram: usize,
+    ) -> Result<PleTicket> {
+        let (tokens, local_start) = ple_job_tokens(tokens, start, rows, ngram)?;
         let (reply, rx) = mpsc::sync_channel(1);
         self.tx
-            .send(Job { context, reply })
+            .send(Job {
+                tokens,
+                start: local_start,
+                rows,
+                reply,
+            })
             .map_err(|_| anyhow!("qwen4exp PLE worker is not running"))?;
         Ok(PleTicket(rx))
     }
 }
 
-impl WorkerState {
-    fn gather(&self, recent: &[u32]) -> Result<Vec<f32>> {
-        let ctx = ple_context(recent, self.ngram, self.eos)?;
+fn ple_job_tokens(
+    tokens: &[u32],
+    start: usize,
+    rows: usize,
+    ngram: usize,
+) -> Result<(Vec<u32>, usize)> {
+    let end = start
+        .checked_add(rows)
+        .context("PLE token range overflow")?;
+    let begin = start.saturating_sub(ngram.saturating_sub(1));
+    let context = tokens
+        .get(begin..end)
+        .with_context(|| {
+            format!(
+                "PLE token range {start}..{end} outside stream of {}",
+                tokens.len()
+            )
+        })?
+        .to_vec();
+    Ok((context, start - begin))
+}
 
-        let indices = ple_row_indices(
-            &ctx,
-            self.ngram,
-            self.heads_per_ngram,
-            &self.multipliers,
-            &self.offsets,
-            &self.vocab_sizes,
-        );
-        let mut out = Vec::with_capacity(indices.len() * self.row_dim);
-        for row in indices {
-            let row = usize::try_from(row).context("PLE row index overflow")?;
-            if row >= self.rows {
-                bail!(
-                    "qwen4exp PLE row {row} is outside table with {} rows",
-                    self.rows
-                );
+impl WorkerState {
+    fn gather_range(&self, tokens: &[u32], start: usize, rows: usize) -> Result<Vec<f32>> {
+        let heads = (self.ngram - 1) * self.heads_per_ngram;
+        let mut out = Vec::with_capacity(rows * heads * self.row_dim);
+        for pos in start..start + rows {
+            let recent = tokens
+                .get(..=pos)
+                .context("PLE local token range is inconsistent")?;
+            let ctx = ple_context(recent, self.ngram, self.eos)?;
+            let indices = ple_row_indices(
+                &ctx,
+                self.ngram,
+                self.heads_per_ngram,
+                &self.multipliers,
+                &self.offsets,
+                &self.vocab_sizes,
+            );
+            for row in indices {
+                let row = usize::try_from(row).context("PLE row index overflow")?;
+                if row >= self.rows {
+                    bail!(
+                        "qwen4exp PLE row {row} is outside table with {} rows",
+                        self.rows
+                    );
+                }
+                let off = row
+                    .checked_mul(self.row_bytes)
+                    .context("PLE byte offset overflow")?;
+                let end = off
+                    .checked_add(self.row_bytes)
+                    .context("PLE byte range overflow")?;
+                let values = infr_gguf::dequant::dequant_block(self.dtype, &self.table[off..end])
+                    .with_context(|| format!("dequant qwen4exp PLE row {row}"))?;
+                if values.len() != self.row_dim {
+                    bail!(
+                        "qwen4exp PLE row {row} dequantized to {} values, expected {}",
+                        values.len(),
+                        self.row_dim
+                    );
+                }
+                out.extend_from_slice(&values);
             }
-            let off = row
-                .checked_mul(self.row_bytes)
-                .context("PLE byte offset overflow")?;
-            let end = off
-                .checked_add(self.row_bytes)
-                .context("PLE byte range overflow")?;
-            let values = infr_gguf::dequant::dequant_block(self.dtype, &self.table[off..end])
-                .with_context(|| format!("dequant qwen4exp PLE row {row}"))?;
-            if values.len() != self.row_dim {
-                bail!(
-                    "qwen4exp PLE row {row} dequantized to {} values, expected {}",
-                    values.len(),
-                    self.row_dim
-                );
-            }
-            out.extend_from_slice(&values);
         }
         Ok(out)
     }
@@ -241,5 +280,16 @@ mod tests {
         assert_eq!(ctx, vec![7, 2, 2]);
         // The current token's own EOS does not hide its predecessors.
         assert_eq!(ple_context(&[9, 8, 2], 3, 2).unwrap(), vec![2, 8, 9]);
+    }
+
+    #[test]
+    fn batched_range_preserves_each_scalar_ngram_context() {
+        let tokens = [5, 7, 11, 13, 17, 19, 23, 29];
+        let (local, start) = ple_job_tokens(&tokens, 3, 4, 4).unwrap();
+        for row in 0..4 {
+            let batched = ple_context(&local[..=start + row], 4, 2).unwrap();
+            let scalar = ple_context(&tokens[..=3 + row], 4, 2).unwrap();
+            assert_eq!(batched, scalar);
+        }
     }
 }

--- a/crates/infr-llama/src/seam/runner.rs
+++ b/crates/infr-llama/src/seam/runner.rs
@@ -2514,9 +2514,8 @@ pub(crate) fn generate_dense_backend(
         let q16 = g.internal(f16d(batch * max_qrow));
         let k16 = g.internal(f16d(batch * max_kvrow));
         let attn = g.internal(f32d(batch * max_qrow));
-        // Qwen3.8 QSA scratch. The model runs one token at a time, so one projected query and raw
-        // key row are reused across all full-attention layers. Packed K/V holds at most the fixed
-        // token budget plus an incomplete compression block.
+        // Qwen3.8 QSA scratch. Index rows are independent in batched Prefill; scalar decode keeps
+        // using the compact gathered K/V buffers below.
         let qsa_ratio = if c.qwen4exp {
             c.compress_ratios.iter().copied().max().unwrap_or(4).max(1)
         } else {
@@ -2529,7 +2528,7 @@ pub(crate) fn generate_dense_backend(
                 g.internal(f32d(batch * c.indexer_n_head * c.indexer_head_size)),
                 g.internal(f16d(batch * c.indexer_n_head * c.indexer_head_size)),
                 g.internal(TensorDesc::new(
-                    vec![(c.indexer_top_k / qsa_ratio).max(1)],
+                    vec![batch * (c.indexer_top_k / qsa_ratio).max(1)],
                     DType::I32,
                 )),
                 g.internal(f16d(max_rows * max_kvrow.max(1))),
@@ -4730,18 +4729,21 @@ pub(crate) fn generate_dense_backend(
                     None
                 };
                 let visible = start_pos + batch;
-                let (attn_k, attn_v, attn_len, attn_pos) = if let Some((ix_q, ix_k, ix_norm)) =
-                    qsa_query.filter(|_| visible > c.indexer_top_k + qsa_ratio - 1)
-                {
-                    assert_eq!(batch, 1, "QSA sparse attention currently requires batch=1");
-                    let complete = visible / qsa_ratio;
-                    let tail = visible % qsa_ratio;
-                    let selected = (c.indexer_top_k / qsa_ratio).min(complete);
+                let qsa_threshold = c.indexer_top_k + qsa_ratio - 1;
+                let batched_qsa = batch > 1 && qsa_query.is_some() && visible > qsa_threshold;
+                if batched_qsa {
+                    assert!(
+                        start_pos + 1 > qsa_threshold,
+                        "a batched QSA span must not cross the dense-to-sparse boundary"
+                    );
+                    let (ix_q, ix_k, ix_norm) = qsa_query.expect("batched QSA query");
+                    let selected = c.indexer_top_k / qsa_ratio;
                     g.push(Op::QsaIndexer {
                         q: ix_q,
                         k_cache: ix_k,
                         k_norm: ix_norm,
                         dst: qsa_indices,
+                        rows: batch as u32,
                         kv_len: visible as u32,
                         n_head: c.indexer_n_head as u32,
                         head_dim: c.indexer_head_size as u32,
@@ -4752,38 +4754,78 @@ pub(crate) fn generate_dense_backend(
                         eps,
                         scale: 1.0 / (c.indexer_head_size as f32).sqrt(),
                     });
-                    g.push(Op::QsaGather {
+                    g.push(Op::QsaBatchAttention {
+                        q: q_attn,
                         k_cache: k_cache[kv_src],
                         v_cache: v_cache[kv_src],
                         indices: qsa_indices,
-                        k_dst: qsa_gather_k,
-                        v_dst: qsa_gather_v,
-                        selected_blocks: selected as u32,
-                        complete_blocks: complete as u32,
-                        tail: tail as u32,
+                        dst: attn,
+                        rows: batch as u32,
+                        kv_len: visible as u32,
+                        n_head: nh as u32,
+                        n_kv: nkv as u32,
+                        head_dim: hd as u32,
+                        top_blocks: selected as u32,
                         ratio: qsa_ratio as u32,
-                        row_elems: kvrow as u32,
+                        scale,
                     });
-                    let gathered = selected * qsa_ratio + tail;
-                    (qsa_gather_k, qsa_gather_v, gathered, gathered - 1)
                 } else {
-                    (k_cache[kv_src], v_cache[kv_src], visible, start_pos)
-                };
-                g.push(Op::Attention {
-                    q: q_attn,
-                    k_cache: attn_k,
-                    v_cache: attn_v,
-                    dst: attn,
-                    rows: batch as u32,
-                    kv_len: attn_len as u32,
-                    n_head: nh as u32,
-                    n_kv: nkv as u32,
-                    head_dim: hd as u32,
-                    scale,
-                    mask,
-                    pos: attn_pos as u32,
-                    sinks: None,
-                });
+                    let (attn_k, attn_v, attn_len, attn_pos) = if let Some((ix_q, ix_k, ix_norm)) =
+                        qsa_query.filter(|_| visible > qsa_threshold)
+                    {
+                        debug_assert_eq!(batch, 1);
+                        let complete = visible / qsa_ratio;
+                        let tail = visible % qsa_ratio;
+                        let selected = (c.indexer_top_k / qsa_ratio).min(complete);
+                        g.push(Op::QsaIndexer {
+                            q: ix_q,
+                            k_cache: ix_k,
+                            k_norm: ix_norm,
+                            dst: qsa_indices,
+                            rows: 1,
+                            kv_len: visible as u32,
+                            n_head: c.indexer_n_head as u32,
+                            head_dim: c.indexer_head_size as u32,
+                            top_blocks: selected as u32,
+                            ratio: qsa_ratio as u32,
+                            rope_dim: c.rope_dim as u32,
+                            theta,
+                            eps,
+                            scale: 1.0 / (c.indexer_head_size as f32).sqrt(),
+                        });
+                        g.push(Op::QsaGather {
+                            k_cache: k_cache[kv_src],
+                            v_cache: v_cache[kv_src],
+                            indices: qsa_indices,
+                            k_dst: qsa_gather_k,
+                            v_dst: qsa_gather_v,
+                            selected_blocks: selected as u32,
+                            complete_blocks: complete as u32,
+                            tail: tail as u32,
+                            ratio: qsa_ratio as u32,
+                            row_elems: kvrow as u32,
+                        });
+                        let gathered = selected * qsa_ratio + tail;
+                        (qsa_gather_k, qsa_gather_v, gathered, gathered - 1)
+                    } else {
+                        (k_cache[kv_src], v_cache[kv_src], visible, start_pos)
+                    };
+                    g.push(Op::Attention {
+                        q: q_attn,
+                        k_cache: attn_k,
+                        v_cache: attn_v,
+                        dst: attn,
+                        rows: batch as u32,
+                        kv_len: attn_len as u32,
+                        n_head: nh as u32,
+                        n_kv: nkv as u32,
+                        head_dim: hd as u32,
+                        scale,
+                        mask,
+                        pos: attn_pos as u32,
+                        sinks: None,
+                    });
+                }
                 // qwen35: per-head SIGMOID output gate applied to the attention output BEFORE the
                 // o-projection (`gate_a` was split out of the interleaved `attn_q` projection above).
                 if c.attn_out_gate {
@@ -6288,9 +6330,9 @@ pub(crate) fn generate_dense_backend(
     // layers; Q2_K/Q3_K is Llama-4-Scout's shipped gate/up (Q2_K) and down (Q3_K); IQ2_S/IQ3_S is
     // the UD-IQ3_S file's expert pair (grid-codebook mmq via shared-LUT staging). The remaining
     // codebook quants (IQ1_*/IQ2_XXS/IQ2_XS/IQ3_XXS/TQ*) have no dp4a-mmq kernel. Qwen3.8 Flash
-    // Next's UD-Q2_K_XL does ship IQ2_XS/IQ3_XXS expert banks, but qwen4exp is deliberately kept
-    // on this per-token prefill loop in v1; its paged id/idm-GEMV floor covers those dtypes. See
-    // MOE_MMQ_DTYPES's exclusions for the batched-kernel boundary.
+    // Next's UD-Q2_K_XL does ship IQ2_XS/IQ3_XXS expert banks; when those banks are paged, its
+    // correctness-first batched path uses the existing shape-general paged id/idm-GEMV floor.
+    // A resident model still needs the ordinary MOE_MMQ_DTYPES eligibility below.
     // `MOE_MMQ_DTYPES` is the SINGLE SOURCE OF TRUTH this closure and the Vulkan adapter's batched
     // `Op::MoeFfn` gate (its `mmq_ok`) both derive from — a mismatch either silently falls back to
     // per-token prefill or compiles a graph the adapter rejects; `moe_mmq_drift_test` (in
@@ -6312,7 +6354,14 @@ pub(crate) fn generate_dense_backend(
     // `build`), and no `batch > 1` V4 graph has ever been EXECUTED — the only V4 fixture that
     // exists writes f32 expert banks, so `moe_batched_ok` is false for it and nothing here could
     // have exercised the chunked shape. Per-token prefill is slower and is what the tests run.
-    let batched_prefill_ok = (c.moe.is_none() || moe_batched_ok) && !c.deepseek4 && !c.qwen4exp;
+    // Qwen3.8's correctness-first batched path may use the existing multi-row paged id-GEMV for
+    // expert dtypes that do not yet have MMQ (IQ2_XS/IQ3_XXS). Its row-aware QSA kernel consumes
+    // F16 K/V in this first batched implementation.
+    let batched_prefill_ok = if c.qwen4exp {
+        k_fmt == DType::F16 && v_fmt == DType::F16 && (be.moe_paged() || moe_batched_ok)
+    } else {
+        (c.moe.is_none() || moe_batched_ok) && !c.deepseek4
+    };
     let decode_start = if prompt.len() - start > 2 && batched_prefill_ok {
         // Batch-prefill the un-cached suffix, all but the last prompt token (positions
         // start..plen-1; rows 0..start are reused from the session cache) — in UBATCH CHUNKS.
@@ -6361,9 +6410,18 @@ pub(crate) fn generate_dense_backend(
         let chunks: Vec<(usize, usize)> = {
             let mut v = Vec::new();
             let mut cs = start;
+            let qsa_boundary = c.qwen4exp.then(|| {
+                let ratio = c.compress_ratios.iter().copied().max().unwrap_or(4).max(1);
+                c.indexer_top_k + ratio - 1
+            });
             while cs < pf_end {
                 let mut ce = (cs + ubatch).min(pf_end);
                 if let Some(boundary) = turn_checkpoint_boundary {
+                    if cs < boundary && boundary < ce {
+                        ce = boundary;
+                    }
+                }
+                if let Some(boundary) = qsa_boundary {
                     if cs < boundary && boundary < ce {
                         ce = boundary;
                     }
@@ -6386,6 +6444,10 @@ pub(crate) fn generate_dense_backend(
             pos: Box<dyn Buffer>,
             /// gemma4-E2B per-layer token rows.
             ipl: Option<Box<dyn Buffer>>,
+            /// Qwen3.8 caller-owned four-stream residual for this batch.
+            qwen_wide: Option<Box<dyn Buffer>>,
+            /// Qwen3.8 PLE rows, flattened in prompt-token order.
+            ple_embd: Option<Box<dyn Buffer>>,
         }
         let mut live: Vec<Option<PfChunk>> = (0..chunks.len()).map(|_| None).collect();
         for (si, span) in spans.iter().enumerate() {
@@ -6469,12 +6531,45 @@ pub(crate) fn generate_dense_backend(
                     } else {
                         None
                     };
+                    let qwen_wide = if c.qwen4exp {
+                        Some(
+                            be.alloc(pf_m * c.hc_mult * ne * 4, BufferUsage::Activations)
+                                .map_err(|e| anyhow!("{e}"))?,
+                        )
+                    } else {
+                        None
+                    };
+                    let ple_embd = if c.qwen4exp {
+                        let rows = ple_worker
+                            .as_ref()
+                            .ok_or_else(|| anyhow!("qwen4exp session has no PLE worker"))?
+                            .submit_range(prompt, cstart, pf_m, c.ple_ngram_size)?
+                            .wait()?;
+                        let heads = (c.ple_ngram_size - 1) * c.ple_heads_per_ngram;
+                        let expected = pf_m * heads * c.ple_head_dim;
+                        if rows.len() != expected {
+                            return Err(anyhow!(
+                                "qwen4exp batched PLE produced {} values, expected {expected}",
+                                rows.len()
+                            ));
+                        }
+                        let b = be
+                            .alloc(rows.len() * 4, BufferUsage::Staging)
+                            .map_err(|e| anyhow!("{e}"))?;
+                        be.upload(b.as_ref(), bytemuck::cast_slice(&rows))
+                            .map_err(|e| anyhow!("{e}"))?;
+                        Some(b)
+                    } else {
+                        None
+                    };
                     live[ci] = Some(PfChunk {
                         m: pf_m,
                         input,
                         resid,
                         pos,
                         ipl,
+                        qwen_wide,
+                        ple_embd,
                     });
                 }
                 let ch = live[ci]
@@ -6535,8 +6630,16 @@ pub(crate) fn generate_dense_backend(
                     &vbufs[..],
                     &qsa_kbufs[..],
                     &wbufs[..],
-                    qwen_wide_buf,
-                    ple_embd_buf,
+                    if c.qwen4exp {
+                        &ch.qwen_wide
+                    } else {
+                        qwen_wide_buf
+                    },
+                    if c.qwen4exp {
+                        &ch.ple_embd
+                    } else {
+                        ple_embd_buf
+                    },
                     ple_state_buf,
                 );
                 debug_assert!(

--- a/crates/infr-llama/src/seam/runner.rs
+++ b/crates/infr-llama/src/seam/runner.rs
@@ -633,20 +633,13 @@ pub(crate) fn generate_dense_backend(
     // unconditionally, so the pair is forced to f16 — and a NAMED non-f16 format is refused here
     // rather than silently downgraded. `crate::seam::mla_kv_fmt` owns the rule and its argument.
     (k_fmt, v_fmt) = crate::seam::mla_kv_fmt(c, be.name(), ec, k_fmt, v_fmt)?;
-    if c.qwen4exp {
-        let named_non_f16 =
-            |specified: bool, dt: Option<DType>| specified && !matches!(dt, Some(DType::F16));
-        if named_non_f16(ec.kv.type_k_specified, ec.kv.type_k)
-            || named_non_f16(ec.kv.type_v_specified, ec.kv.type_v)
-            || ec.kv.force_q8
-        {
-            return Err(anyhow!(
-                "qwen4exp v1 supports F16 KV only; remove the KV override or set both \
-                 kv.type_k=f16 and kv.type_v=f16"
-            ));
-        }
-        k_fmt = DType::F16;
-        v_fmt = DType::F16;
+    if c.qwen4exp
+        && (!matches!(k_fmt, DType::F16 | DType::Q8_0)
+            || !matches!(v_fmt, DType::F16 | DType::Q8_0))
+    {
+        return Err(anyhow!(
+            "qwen4exp supports F16 and Q8_0 KV; got k={k_fmt:?}, v={v_fmt:?}"
+        ));
     }
 
     // SWA ring KV: window layers allocate `min(want_ctx, window + ubatch)` rows and the backend
@@ -6356,9 +6349,11 @@ pub(crate) fn generate_dense_backend(
     // have exercised the chunked shape. Per-token prefill is slower and is what the tests run.
     // Qwen3.8's correctness-first batched path may use the existing multi-row paged id-GEMV for
     // expert dtypes that do not yet have MMQ (IQ2_XS/IQ3_XXS). Its row-aware QSA kernel consumes
-    // F16 K/V in this first batched implementation.
+    // either F16 or planar-Q8 K/V.
     let batched_prefill_ok = if c.qwen4exp {
-        k_fmt == DType::F16 && v_fmt == DType::F16 && (be.moe_paged() || moe_batched_ok)
+        matches!(k_fmt, DType::F16 | DType::Q8_0)
+            && matches!(v_fmt, DType::F16 | DType::Q8_0)
+            && (be.moe_paged() || moe_batched_ok)
     } else {
         (c.moe.is_none() || moe_batched_ok) && !c.deepseek4
     };

--- a/crates/infr-vulkan/build.rs
+++ b/crates/infr-vulkan/build.rs
@@ -667,6 +667,7 @@ fn main() {
         ("qsa_indexer_score", "qsa_indexer_score", &[]),
         ("qsa_indexer_topk", "qsa_indexer_topk", &[]),
         ("qsa_gather", "qsa_gather", &[]),
+        ("qsa_attention_batch", "qsa_attention_batch", &[]),
         // DeepSeek V4 Sinkhorn hyper-connections (Op::HyperConnectMix / Pre / Post). `-DGATES`
         // adds the `post` + `comb` outputs; without it the mix kernel is `build_hc_head`'s
         // pre-only form, whose `mixes` is the pre chunk alone.

--- a/crates/infr-vulkan/build.rs
+++ b/crates/infr-vulkan/build.rs
@@ -1788,6 +1788,25 @@ fn main() {
             "native_idm_iq3s_sg8_paged",
             &["-DFMT_IQ3S", "-DUSE_GRID", "-DNR=8", "-DPAGED"],
         ),
+        // Qwen3.8's paged 2560x640 IQ2_XS gate/up banks: NR=8 stages the 4 KiB codebook once
+        // for eight output rows. Both routed-only and routed+fixed-Q8-shared variants are kept;
+        // the exact shape gate lives in `native_id_sg_choice`.
+        (
+            "native_gemv_id_multi_sg",
+            "native_idm_iq2xs_sg8_paged",
+            &["-DFMT_IQ2XS", "-DUSE_GRID", "-DNR=8", "-DPAGED"],
+        ),
+        (
+            "native_gemv_id_multi_sg",
+            "native_idm_iq2xs_sg8_paged_shexp",
+            &[
+                "-DFMT_IQ2XS",
+                "-DUSE_GRID",
+                "-DNR=8",
+                "-DPAGED",
+                "-DSHARED_Q8",
+            ],
+        ),
         ("moe_accumulate", "moe_accumulate", &[]),
         ("moe_accumulate_scaled", "moe_accumulate_scaled", &[]),
         ("moe_accumulate_shared", "moe_accumulate_shared", &[]),

--- a/crates/infr-vulkan/build.rs
+++ b/crates/infr-vulkan/build.rs
@@ -667,7 +667,17 @@ fn main() {
         ("qsa_indexer_score", "qsa_indexer_score", &[]),
         ("qsa_indexer_topk", "qsa_indexer_topk", &[]),
         ("qsa_gather", "qsa_gather", &[]),
+        ("qsa_gather", "qsa_gather_kq8", &["-DKQ8"]),
+        ("qsa_gather", "qsa_gather_vq8", &["-DVQ8"]),
+        ("qsa_gather", "qsa_gather_q8", &["-DKQ8", "-DVQ8"]),
         ("qsa_attention_batch", "qsa_attention_batch", &[]),
+        ("qsa_attention_batch", "qsa_attention_batch_kq8", &["-DKQ8"]),
+        ("qsa_attention_batch", "qsa_attention_batch_vq8", &["-DVQ8"]),
+        (
+            "qsa_attention_batch",
+            "qsa_attention_batch_q8",
+            &["-DKQ8", "-DVQ8"],
+        ),
         // DeepSeek V4 Sinkhorn hyper-connections (Op::HyperConnectMix / Pre / Post). `-DGATES`
         // adds the `post` + `comb` outputs; without it the mix kernel is `build_hc_head`'s
         // pre-only form, whose `mixes` is the pre chunk alone.

--- a/crates/infr-vulkan/build.rs
+++ b/crates/infr-vulkan/build.rs
@@ -1807,6 +1807,11 @@ fn main() {
                 "-DSHARED_Q8",
             ],
         ),
+        (
+            "native_gemv_id_swiglu_sg",
+            "native_id_swiglu_iq2xs_sg8_paged",
+            &["-DNR=8"],
+        ),
         ("moe_accumulate", "moe_accumulate", &[]),
         ("moe_accumulate_scaled", "moe_accumulate_scaled", &[]),
         ("moe_accumulate_shared", "moe_accumulate_shared", &[]),

--- a/crates/infr-vulkan/shaders/native_gemv_id_swiglu_sg.comp
+++ b/crates/infr-vulkan/shaders/native_gemv_id_swiglu_sg.comp
@@ -1,0 +1,98 @@
+#version 460
+// Fused paged gate+up IQ2_XS GEMV and SwiGLU for Qwen3.8 decode. One subgroup owns NR output
+// rows for one routed expert. Gate and up share the activation row, selected expert id, and the
+// 4 KiB IQ2_XS codebook staged by GRID_INIT; only their weight addresses differ. The two dot
+// products retain the existing subgroup+NR reduction order, then lane 0 writes silu(gate)*up
+// directly, removing both intermediate buffers from the command stream.
+#extension GL_KHR_shader_subgroup_basic : require
+#extension GL_KHR_shader_subgroup_arithmetic : require
+#extension GL_EXT_control_flow_attributes : require
+
+#ifndef SG
+#define SG 32
+#endif
+#ifndef NR
+#define NR 8
+#endif
+layout(local_size_x = SG, local_size_y = 1, local_size_z = 1) in;
+
+layout(push_constant) uniform PC {
+    uint in_f;
+    uint out_f;
+    uint n_used;
+    uint gate_lut_base;
+    uint up_lut_base;
+    uint rows;
+    uint active_mask;
+} pc;
+
+layout(binding = 0) readonly buffer XB { float x_buf[]; };
+layout(binding = 1) readonly buffer IDB { uint ids[]; };
+layout(binding = 2) readonly buffer GLB { uvec2 gate_lut[]; };
+layout(binding = 3) readonly buffer ULB { uvec2 up_lut[]; };
+layout(binding = 4) writeonly buffer YB { float y_buf[]; };
+
+#include "native_weight_addr.glsl"
+#define NW(i) arena_word(i)
+#define FMT_IQ2XS
+#define USE_GRID
+#include "native_decode.glsl"
+
+float dot_at(uint64_t addr, uint gstart, uint xoff) {
+    w_addr = addr;
+    float v[32];
+    dqblk(gstart, v);
+    float a = 0.0;
+    for (uint w = 0u; w < 32u; w++) { a += v[w] * x_buf[xoff + w]; }
+    return a;
+}
+
+void main() {
+    GRID_INIT;
+    uint lane = gl_SubgroupInvocationID;
+    uint og = (pc.out_f + uint(NR) - 1u) / uint(NR);
+    uint unit = gl_WorkGroupID.x + gl_WorkGroupID.y * gl_NumWorkGroups.x;
+    if (unit >= pc.rows * pc.n_used * og) { return; }
+    uint slot_global = unit / og;
+    uint o0 = (unit - slot_global * og) * uint(NR);
+    uint row = slot_global / pc.n_used;
+    uint slot = slot_global - row * pc.n_used;
+    if ((pc.active_mask & (1u << slot)) == 0u) { return; }
+
+    uint expert = ids[slot_global];
+    uvec2 ga = gate_lut[pc.gate_lut_base + expert];
+    uvec2 ua = up_lut[pc.up_lut_base + expert];
+    uint64_t gate_addr = arena_base(ga.x, ga.y);
+    uint64_t up_addr = arena_base(ua.x, ua.y);
+    // A zero tape address denotes a non-resident expert. Production reaches this kernel after
+    // staging, but keeping the guard here makes a stale/partial window fail closed, not fault BDA.
+    if (gate_addr == 0ul || up_addr == 0ul) { return; }
+
+    uint xbase = row * pc.in_f;
+    uint nsub = pc.in_f / 32u;
+    float gate_acc[NR];
+    float up_acc[NR];
+    [[unroll]] for (uint rr = 0u; rr < uint(NR); rr++) {
+        gate_acc[rr] = 0.0;
+        up_acc[rr] = 0.0;
+    }
+    for (uint s = lane; s < nsub; s += uint(SG)) {
+        uint xoff = xbase + s * 32u;
+        [[unroll]] for (uint rr = 0u; rr < uint(NR); rr++) {
+            uint o = o0 + rr;
+            if (o < pc.out_f) {
+                uint woff = o * pc.in_f + s * 32u;
+                gate_acc[rr] += dot_at(gate_addr, woff, xoff);
+                up_acc[rr] += dot_at(up_addr, woff, xoff);
+            }
+        }
+    }
+    [[unroll]] for (uint rr = 0u; rr < uint(NR); rr++) {
+        float gate = subgroupAdd(gate_acc[rr]);
+        float up = subgroupAdd(up_acc[rr]);
+        uint o = o0 + rr;
+        if (lane == 0u && o < pc.out_f) {
+            y_buf[slot_global * pc.out_f + o] = gate / (1.0 + exp(-gate)) * up;
+        }
+    }
+}

--- a/crates/infr-vulkan/shaders/qsa_attention_batch.comp
+++ b/crates/infr-vulkan/shaders/qsa_attention_batch.comp
@@ -1,6 +1,6 @@
 #version 460
 // Correctness-first batched Qwen3.8 QSA attention. One workgroup owns one (query row, attention
-// head), reads that row's selected complete blocks directly from F16 KV caches,
+// head), reads that row's selected complete blocks directly from F16 or planar-Q8 KV caches,
 // appends its incomplete causal tail, and performs an exact two-pass softmax. Each lane owns one
 // element of a 128-wide head or two elements of Qwen3.8's 256-wide attention head.
 layout(local_size_x = 128, local_size_y = 1, local_size_z = 1) in;
@@ -14,6 +14,8 @@ layout(push_constant) uniform PC {
     uint top_blocks;
     uint ratio;
     float scale;
+    uint kcap;
+    uint vcap;
 } pc;
 layout(binding = 0) readonly buffer QB { uint q[]; };
 layout(binding = 1) readonly buffer KB { uint k[]; };
@@ -33,15 +35,31 @@ float qread(uint i) {
 }
 
 float kread(uint i) {
+#ifdef KQ8
+    int codes = int(k[i >> 2u]);
+    int code = bitfieldExtract(codes, int((i & 3u) * 8u), 8);
+    uint block = i >> 5u;
+    float scale = unpackHalf2x16(k[(pc.kcap >> 2u) + (block >> 1u)])[block & 1u];
+    return scale * float(code);
+#else
     uint w = k[i >> 1u];
     uint h = (i & 1u) == 0u ? w & 0xffffu : w >> 16u;
     return unpackHalf2x16(h).x;
+#endif
 }
 
 float vread(uint i) {
+#ifdef VQ8
+    int codes = int(v[i >> 2u]);
+    int code = bitfieldExtract(codes, int((i & 3u) * 8u), 8);
+    uint block = i >> 5u;
+    float scale = unpackHalf2x16(v[(pc.vcap >> 2u) + (block >> 1u)])[block & 1u];
+    return scale * float(code);
+#else
     uint w = v[i >> 1u];
     uint h = (i & 1u) == 0u ? w & 0xffffu : w >> 16u;
     return unpackHalf2x16(h).x;
+#endif
 }
 
 uint source_row(uint row, uint logical, uint selected, uint complete) {

--- a/crates/infr-vulkan/shaders/qsa_attention_batch.comp
+++ b/crates/infr-vulkan/shaders/qsa_attention_batch.comp
@@ -1,0 +1,118 @@
+#version 460
+// Correctness-first batched Qwen3.8 QSA attention. One workgroup owns one (query row, attention
+// head), reads that row's selected complete blocks directly from F16 KV caches,
+// appends its incomplete causal tail, and performs an exact two-pass softmax. Each lane owns one
+// element of a 128-wide head or two elements of Qwen3.8's 256-wide attention head.
+layout(local_size_x = 128, local_size_y = 1, local_size_z = 1) in;
+
+layout(push_constant) uniform PC {
+    uint rows;
+    uint kv_len;
+    uint n_head;
+    uint n_kv;
+    uint head_dim;
+    uint top_blocks;
+    uint ratio;
+    float scale;
+} pc;
+layout(binding = 0) readonly buffer QB { uint q[]; };
+layout(binding = 1) readonly buffer KB { uint k[]; };
+layout(binding = 2) readonly buffer VB { uint v[]; };
+layout(binding = 3) readonly buffer IB { uint indices[]; };
+layout(binding = 4) writeonly buffer DB { float dst[]; };
+
+shared float partial[128];
+shared float row_max;
+shared float row_sum;
+shared float row_exp;
+
+float qread(uint i) {
+    uint w = q[i >> 1u];
+    uint h = (i & 1u) == 0u ? w & 0xffffu : w >> 16u;
+    return unpackHalf2x16(h).x;
+}
+
+float kread(uint i) {
+    uint w = k[i >> 1u];
+    uint h = (i & 1u) == 0u ? w & 0xffffu : w >> 16u;
+    return unpackHalf2x16(h).x;
+}
+
+float vread(uint i) {
+    uint w = v[i >> 1u];
+    uint h = (i & 1u) == 0u ? w & 0xffffu : w >> 16u;
+    return unpackHalf2x16(h).x;
+}
+
+uint source_row(uint row, uint logical, uint selected, uint complete) {
+    uint selected_rows = selected * pc.ratio;
+    if (logical < selected_rows) {
+        uint slot = logical / pc.ratio;
+        uint block = indices[row * pc.top_blocks + slot];
+        return block * pc.ratio + logical % pc.ratio;
+    }
+    return complete * pc.ratio + logical - selected_rows;
+}
+
+float score_key(uint qbase, uint kbase, uint d) {
+    float sum = qread(qbase + d) * kread(kbase + d);
+    if (pc.head_dim == 256u) {
+        sum += qread(qbase + d + 128u) * kread(kbase + d + 128u);
+    }
+    partial[d] = sum;
+    barrier();
+    for (uint stride = 64u; stride > 0u; stride >>= 1u) {
+        if (d < stride) { partial[d] += partial[d + stride]; }
+        barrier();
+    }
+    return partial[0] * pc.scale;
+}
+
+void main() {
+    uint job = gl_WorkGroupID.x + gl_WorkGroupID.y * gl_NumWorkGroups.x;
+    uint row = job / pc.n_head;
+    uint head = job - row * pc.n_head;
+    if (row >= pc.rows || (pc.head_dim != 128u && pc.head_dim != 256u)) { return; }
+    uint d = gl_LocalInvocationID.x;
+    uint group = pc.n_head / pc.n_kv;
+    uint kv_head = head / group;
+    uint visible = pc.kv_len - pc.rows + row + 1u;
+    uint complete = visible / pc.ratio;
+    uint tail = visible - complete * pc.ratio;
+    uint selected = min(pc.top_blocks, complete);
+    uint keys = selected * pc.ratio + tail;
+    uint qbase = (row * pc.n_head + head) * pc.head_dim;
+
+    if (d == 0u) { row_max = -3.402823466e+38; }
+    barrier();
+    for (uint logical = 0u; logical < keys; ++logical) {
+        uint src_row = source_row(row, logical, selected, complete);
+        uint kbase = (src_row * pc.n_kv + kv_head) * pc.head_dim;
+        float logit = score_key(qbase, kbase, d);
+        if (d == 0u) { row_max = max(row_max, logit); }
+        barrier();
+    }
+
+    if (d == 0u) { row_sum = 0.0; }
+    float accum0 = 0.0;
+    float accum1 = 0.0;
+    barrier();
+    for (uint logical = 0u; logical < keys; ++logical) {
+        uint src_row = source_row(row, logical, selected, complete);
+        uint base = (src_row * pc.n_kv + kv_head) * pc.head_dim;
+        float logit = score_key(qbase, base, d);
+        if (d == 0u) {
+            row_exp = exp(logit - row_max);
+            row_sum += row_exp;
+        }
+        barrier();
+        accum0 += row_exp * vread(base + d);
+        if (pc.head_dim == 256u) {
+            accum1 += row_exp * vread(base + d + 128u);
+        }
+        barrier();
+    }
+    uint out_base = (row * pc.n_head + head) * pc.head_dim + d;
+    dst[out_base] = accum0 / row_sum;
+    if (pc.head_dim == 256u) { dst[out_base + 128u] = accum1 / row_sum; }
+}

--- a/crates/infr-vulkan/shaders/qsa_gather.comp
+++ b/crates/infr-vulkan/shaders/qsa_gather.comp
@@ -1,5 +1,6 @@
 #version 460
-// Gather selected complete QSA blocks and the incomplete causal tail from ordinary packed-F16 KV.
+// Gather selected complete QSA blocks and the incomplete causal tail into packed-F16 scratch.
+// KQ8/VQ8 read infr's planar KV layout: int8 codes in [0, cap), then one f16 scale per 32 codes.
 layout(local_size_x = 256, local_size_y = 1, local_size_z = 1) in;
 
 layout(push_constant) uniform PC {
@@ -9,12 +10,34 @@ layout(push_constant) uniform PC {
     uint ratio;
     uint row_pairs;
     uint total_pairs;
+    uint kcap;
+    uint vcap;
 } pc;
 layout(binding = 0) readonly buffer KB { uint k[]; };
 layout(binding = 1) readonly buffer VB { uint v[]; };
 layout(binding = 2) readonly buffer IB { uint indices[]; };
 layout(binding = 3) writeonly buffer KDB { uint kd[]; };
 layout(binding = 4) writeonly buffer VDB { uint vd[]; };
+
+#ifdef KQ8
+float kread(uint i) {
+    int codes = int(k[i >> 2u]);
+    int code = bitfieldExtract(codes, int((i & 3u) * 8u), 8);
+    uint block = i >> 5u;
+    float scale = unpackHalf2x16(k[(pc.kcap >> 2u) + (block >> 1u)])[block & 1u];
+    return scale * float(code);
+}
+#endif
+
+#ifdef VQ8
+float vread(uint i) {
+    int codes = int(v[i >> 2u]);
+    int code = bitfieldExtract(codes, int((i & 3u) * 8u), 8);
+    uint block = i >> 5u;
+    float scale = unpackHalf2x16(v[(pc.vcap >> 2u) + (block >> 1u)])[block & 1u];
+    return scale * float(code);
+}
+#endif
 
 void main() {
     uint pair = gl_GlobalInvocationID.x;
@@ -29,7 +52,17 @@ void main() {
     } else {
         src_row = pc.complete * pc.ratio + out_row - selected_rows;
     }
-    uint src = src_row * pc.row_pairs + in_row;
-    kd[pair] = k[src];
-    vd[pair] = v[src];
+    uint src_pair = src_row * pc.row_pairs + in_row;
+#ifdef KQ8
+    uint ke = src_pair * 2u;
+    kd[pair] = packHalf2x16(vec2(kread(ke), kread(ke + 1u)));
+#else
+    kd[pair] = k[src_pair];
+#endif
+#ifdef VQ8
+    uint ve = src_pair * 2u;
+    vd[pair] = packHalf2x16(vec2(vread(ve), vread(ve + 1u)));
+#else
+    vd[pair] = v[src_pair];
+#endif
 }

--- a/crates/infr-vulkan/shaders/qsa_indexer_score.comp
+++ b/crates/infr-vulkan/shaders/qsa_indexer_score.comp
@@ -4,6 +4,7 @@
 layout(local_size_x = 128, local_size_y = 1, local_size_z = 1) in;
 
 layout(push_constant) uniform PC {
+    uint rows;
     uint kv_len;
     uint n_head;
     uint head_dim;
@@ -34,8 +35,13 @@ float kread(uint i) {
 }
 
 void main() {
-    uint block = gl_WorkGroupID.x + gl_WorkGroupID.y * gl_NumWorkGroups.x;
-    uint blocks = pc.kv_len / pc.ratio;
+    uint job = gl_WorkGroupID.x + gl_WorkGroupID.y * gl_NumWorkGroups.x;
+    uint max_blocks = pc.kv_len / pc.ratio;
+    uint row = job / max_blocks;
+    uint block = job - row * max_blocks;
+    if (row >= pc.rows) { return; }
+    uint visible = pc.kv_len - pc.rows + row + 1u;
+    uint blocks = visible / pc.ratio;
     if (block >= blocks) { return; }
     uint d = gl_LocalInvocationID.x;
 
@@ -68,7 +74,8 @@ void main() {
     }
 
     for (uint h = 0u; h < 4u; ++h) {
-        part[h][d] = h < pc.n_head ? qread(h * pc.head_dim + d) * kn : 0.0;
+        uint qbase = row * pc.n_head * pc.head_dim;
+        part[h][d] = h < pc.n_head ? qread(qbase + h * pc.head_dim + d) * kn : 0.0;
     }
     barrier();
     for (uint stride = 64u; stride > 0u; stride >>= 1u) {
@@ -80,6 +87,6 @@ void main() {
     if (d == 0u) {
         float score = 0.0;
         for (uint h = 0u; h < pc.n_head; ++h) { score += max(part[h][0], 0.0); }
-        scores[block] = score * pc.scale;
+        scores[row * max_blocks + block] = score * pc.scale;
     }
 }

--- a/crates/infr-vulkan/shaders/qsa_indexer_topk.comp
+++ b/crates/infr-vulkan/shaders/qsa_indexer_topk.comp
@@ -1,6 +1,10 @@
 #version 460
 // Exact score-desc/index-asc top-k, followed by an index-ascending bitonic sort. The latter
 // reproduces scatter-to-mask attention order: selected tokens are consumed chronologically.
+//
+// Select the k-th key with a 4-bit radix pass over (ordered-score, ~index). This preserves the
+// original total order while scanning the score vector 16 times instead of top_k times. Qwen3.8
+// selects 512 of up to 65536 blocks, so the old repeated maximum reduction dominated decode.
 layout(local_size_x = 256, local_size_y = 1, local_size_z = 1) in;
 
 layout(push_constant) uniform PC {
@@ -14,16 +18,15 @@ layout(binding = 0) readonly buffer SB { float scores[]; };
 layout(binding = 1) writeonly buffer DB { uint dst[]; };
 
 #define INVALID 0xffffffffu
-shared float sval[256];
-shared uint sidx[256];
-shared float prev_val;
-shared uint prev_idx;
+shared uint bucket[16];
+shared uint selected_digit;
+shared uint remaining_rank;
+shared uint selected_count;
 shared uint chosen[512];
 
-bool above(uint ai, float av, uint bi, float bv) {
-    if (ai == INVALID) { return false; }
-    if (bi == INVALID) { return true; }
-    return av != bv ? av > bv : ai < bi;
+uint ordered_float(float x) {
+    uint bits = floatBitsToUint(x);
+    return (bits & 0x80000000u) != 0u ? ~bits : bits | 0x80000000u;
 }
 
 void main() {
@@ -33,31 +36,76 @@ void main() {
     uint blocks = (pc.kv_len - pc.rows + row + 1u) / pc.ratio;
     uint score_base = row * pc.max_blocks;
     uint dst_base = row * pc.top_k;
-    for (uint rank = 0u; rank < pc.top_k; ++rank) {
-        uint bi = INVALID;
-        float bv = 0.0;
-        for (uint j = t; j < blocks; j += 256u) {
-            float s = scores[score_base + j];
-            if (rank > 0u && !above(prev_idx, prev_val, j, s)) { continue; }
-            if (above(j, s, bi, bv)) { bi = j; bv = s; }
-        }
-        sidx[t] = bi;
-        sval[t] = bv;
+    uint prefix_score = 0u;
+    uint prefix_index = 0u;
+    uint rank = pc.top_k;
+
+    // A score contributes the high 32 bits. The complemented index contributes the low 32 bits,
+    // making a smaller source index rank above a larger one when scores tie.
+    for (uint level = 0u; level < 16u; ++level) {
+        if (t < 16u) { bucket[t] = 0u; }
         barrier();
-        for (uint stride = 128u; stride > 0u; stride >>= 1u) {
-            if (t < stride && above(sidx[t + stride], sval[t + stride], sidx[t], sval[t])) {
-                sidx[t] = sidx[t + stride];
-                sval[t] = sval[t + stride];
+
+        for (uint j = t; j < blocks; j += 256u) {
+            uint score_key = ordered_float(scores[score_base + j]);
+            uint index_key = ~j;
+            uint digit;
+            if (level < 8u) {
+                uint done = level * 4u;
+                uint mask = done == 0u ? 0u : 0xffffffffu << (32u - done);
+                if ((score_key & mask) != (prefix_score & mask)) { continue; }
+                digit = (score_key >> (28u - done)) & 0xfu;
+            } else {
+                if (score_key != prefix_score) { continue; }
+                uint done = (level - 8u) * 4u;
+                uint mask = done == 0u ? 0u : 0xffffffffu << (32u - done);
+                if ((index_key & mask) != (prefix_index & mask)) { continue; }
+                digit = (index_key >> (28u - done)) & 0xfu;
             }
-            barrier();
+            atomicAdd(bucket[digit], 1u);
         }
+        barrier();
+
         if (t == 0u) {
-            chosen[rank] = sidx[0];
-            prev_idx = sidx[0];
-            prev_val = sval[0];
+            uint above = 0u;
+            uint digit = 0u;
+            uint next_rank = rank;
+            for (int b = 15; b >= 0; --b) {
+                uint count = bucket[uint(b)];
+                if (above + count >= rank) {
+                    digit = uint(b);
+                    next_rank = rank - above;
+                    break;
+                }
+                above += count;
+            }
+            selected_digit = digit;
+            remaining_rank = next_rank;
         }
+        barrier();
+
+        if (level < 8u) {
+            prefix_score |= selected_digit << (28u - level * 4u);
+        } else {
+            prefix_index |= selected_digit << (28u - (level - 8u) * 4u);
+        }
+        rank = remaining_rank;
         barrier();
     }
+
+    // The index component makes every key unique, so exactly top_k entries are >= the threshold.
+    if (t == 0u) { selected_count = 0u; }
+    barrier();
+    for (uint j = t; j < blocks; j += 256u) {
+        uint score_key = ordered_float(scores[score_base + j]);
+        uint index_key = ~j;
+        if (score_key > prefix_score ||
+            (score_key == prefix_score && index_key >= prefix_index)) {
+            uint slot = atomicAdd(selected_count, 1u);
+            if (slot < pc.top_k) { chosen[slot] = j; }
+        }
+    }
+    barrier();
 
     uint i0 = t;
     uint i1 = t + 256u;

--- a/crates/infr-vulkan/shaders/qsa_indexer_topk.comp
+++ b/crates/infr-vulkan/shaders/qsa_indexer_topk.comp
@@ -3,7 +3,13 @@
 // reproduces scatter-to-mask attention order: selected tokens are consumed chronologically.
 layout(local_size_x = 256, local_size_y = 1, local_size_z = 1) in;
 
-layout(push_constant) uniform PC { uint blocks; uint top_k; } pc;
+layout(push_constant) uniform PC {
+    uint max_blocks;
+    uint top_k;
+    uint rows;
+    uint kv_len;
+    uint ratio;
+} pc;
 layout(binding = 0) readonly buffer SB { float scores[]; };
 layout(binding = 1) writeonly buffer DB { uint dst[]; };
 
@@ -22,11 +28,16 @@ bool above(uint ai, float av, uint bi, float bv) {
 
 void main() {
     uint t = gl_LocalInvocationID.x;
+    uint row = gl_WorkGroupID.x;
+    if (row >= pc.rows) { return; }
+    uint blocks = (pc.kv_len - pc.rows + row + 1u) / pc.ratio;
+    uint score_base = row * pc.max_blocks;
+    uint dst_base = row * pc.top_k;
     for (uint rank = 0u; rank < pc.top_k; ++rank) {
         uint bi = INVALID;
         float bv = 0.0;
-        for (uint j = t; j < pc.blocks; j += 256u) {
-            float s = scores[j];
+        for (uint j = t; j < blocks; j += 256u) {
+            float s = scores[score_base + j];
             if (rank > 0u && !above(prev_idx, prev_val, j, s)) { continue; }
             if (above(j, s, bi, bv)) { bi = j; bv = s; }
         }
@@ -71,6 +82,6 @@ void main() {
             barrier();
         }
     }
-    if (i0 < pc.top_k) { dst[i0] = chosen[i0]; }
-    if (i1 < pc.top_k) { dst[i1] = chosen[i1]; }
+    if (i0 < pc.top_k) { dst[dst_base + i0] = chosen[i0]; }
+    if (i1 < pc.top_k) { dst[dst_base + i1] = chosen[i1]; }
 }

--- a/crates/infr-vulkan/src/adapter.rs
+++ b/crates/infr-vulkan/src/adapter.rs
@@ -208,7 +208,8 @@ fn decode_eligible(be_: &VulkanBackend, graph: &Graph) -> bool {
             | Op::Dsv4Indexer { .. }
             | Op::Dsv4Gather { .. }
             | Op::QsaIndexer { .. }
-            | Op::QsaGather { .. } => return false,
+            | Op::QsaGather { .. }
+            | Op::QsaBatchAttention { .. } => return false,
             // Any mask (SWA windows ride push constants + the window-aware prologue) and any
             // scale (gemma4 uses 1.0) — both are baked per-layer into the recorded dispatch.
             // hd%4 ≤ 512 keeps every layer on the self-chunking split path or the scalar
@@ -2578,6 +2579,7 @@ fn lower_op(
             k_cache,
             k_norm,
             dst,
+            rows,
             kv_len,
             n_head,
             head_dim,
@@ -2589,30 +2591,40 @@ fn lower_op(
             scale,
         } => {
             let blocks = *kv_len / *ratio.max(&1);
+            let first_visible = kv_len.saturating_sub(*rows).saturating_add(1);
+            let first_blocks = first_visible / *ratio.max(&1);
             if *head_dim != 128
+                || *rows == 0
+                || *rows > *kv_len
                 || *n_head == 0
                 || *n_head > 4
                 || *ratio == 0
                 || *rope_dim > *head_dim
                 || !rope_dim.is_multiple_of(2)
                 || *top_blocks == 0
-                || *top_blocks > blocks
+                || *top_blocks > first_blocks
                 || *top_blocks > 512
             {
                 return Err(be(format!(
                     "vulkan Op::QsaIndexer requires head_dim=128, 1..=4 heads, even rope_dim, \
                      ratio>0 and 0<top_blocks<=min(blocks,512); got head_dim={head_dim} \
                      n_head={n_head} rope_dim={rope_dim} ratio={ratio} top_blocks={top_blocks} \
-                     kv_len={kv_len}"
+                     rows={rows} kv_len={kv_len}"
                 )));
             }
-            let sk = pooled(pool, be_, "qsa_indexer_scores", blocks as usize * 4)?;
+            let sk = pooled(
+                pool,
+                be_,
+                "qsa_indexer_scores",
+                *rows as usize * blocks as usize * 4,
+            )?;
             rec.qsa_indexer(
                 r(*q)?,
                 r(*k_cache)?,
                 r(*k_norm)?,
                 pool[&sk].as_ref(),
                 r(*dst)?,
+                *rows,
                 *kv_len,
                 *n_head,
                 *head_dim,
@@ -2658,6 +2670,64 @@ fn lower_op(
                 *tail,
                 *ratio,
                 *row_elems,
+            );
+        }
+        Op::QsaBatchAttention {
+            q,
+            k_cache,
+            v_cache,
+            indices,
+            dst,
+            rows,
+            kv_len,
+            n_head,
+            n_kv,
+            head_dim,
+            top_blocks,
+            ratio,
+            scale,
+        } => {
+            let first_visible = kv_len.saturating_sub(*rows).saturating_add(1);
+            let first_blocks = first_visible / *ratio.max(&1);
+            let kdt = graph.desc(*k_cache).dtype;
+            let vdt = graph.desc(*v_cache).dtype;
+            if *rows == 0
+                || *rows > *kv_len
+                || *n_head == 0
+                || *n_kv == 0
+                || !n_head.is_multiple_of(*n_kv)
+                || !matches!(*head_dim, 128 | 256)
+                || *ratio == 0
+                || *top_blocks == 0
+                || *top_blocks > first_blocks
+                || *top_blocks > 512
+                || graph.desc(*q).dtype != infr_core::DType::F16
+                || kdt != infr_core::DType::F16
+                || vdt != infr_core::DType::F16
+            {
+                return Err(be(format!(
+                    "vulkan Op::QsaBatchAttention requires F16 q/k/v, rows<=kv_len, \
+                     head_dim=128/256, n_head divisible by n_kv, ratio>0 and \
+                     0<top_blocks<=first complete blocks; \
+                     got rows={rows} kv_len={kv_len} n_head={n_head} n_kv={n_kv} \
+                     head_dim={head_dim} ratio={ratio} top_blocks={top_blocks} \
+                     k_dtype={kdt:?} v_dtype={vdt:?}"
+                )));
+            }
+            rec.qsa_attention_batch(
+                r(*q)?,
+                r(*k_cache)?,
+                r(*v_cache)?,
+                r(*indices)?,
+                r(*dst)?,
+                *rows,
+                *kv_len,
+                *n_head,
+                *n_kv,
+                *head_dim,
+                *top_blocks,
+                *ratio,
+                *scale,
             );
         }
         // Fused per-head RMSNorm + RoPE. Peephole (see `kv_write_peephole`): a QkNormRope whose dst

--- a/crates/infr-vulkan/src/adapter.rs
+++ b/crates/infr-vulkan/src/adapter.rs
@@ -7562,109 +7562,138 @@ fn execute_paged_moe<'a>(
     let n_act = physical_slots * nff;
     let rec2 = rec.as_ref().expect("segment always Some between ops");
     let xb = r(*x)?;
-    {
+    let fused_decode_swiglu = rows == 1
+        && shared.is_none()
+        && !*fused_gate_up
+        && !*weight_before
+        && swiglu_clamp.is_none()
+        && matches!(act, Activation::Silu)
+        && gdt == infr_core::DType::Iq2Xs
+        && udt == infr_core::DType::Iq2Xs
+        && ne == 2560
+        && nff == 640;
+    if fused_decode_swiglu {
         let guard = be_.moe_pager().lock().unwrap();
         let sess = guard.as_ref().expect("checked above");
-        linear_paged_maybe_shared(
-            rec2,
-            gdt,
-            sess.arena_addr(gate_id)?,
-            sess.slot_bytes(gate_id)? as u32,
-            sess.tape(),
+        rec2.linear_native_id_swiglu_iq2xs_paged(
             pool[&ids_key].as_ref(),
             n_used,
+            sess.tape(),
             gate_w as usize,
-            shared_wgate,
+            sess.tape(),
+            up_w as usize,
             xb,
-            false,
-            pool[&gbuf].as_ref(),
+            pool[&abuf].as_ref(),
             ne,
-            gu_width,
+            nff,
             rows,
             active_mask,
         );
-        if let Some(ubuf) = &ubuf {
+    } else {
+        {
+            let guard = be_.moe_pager().lock().unwrap();
+            let sess = guard.as_ref().expect("checked above");
             linear_paged_maybe_shared(
                 rec2,
-                udt,
-                sess.arena_addr(up_id)?,
-                sess.slot_bytes(up_id)? as u32,
+                gdt,
+                sess.arena_addr(gate_id)?,
+                sess.slot_bytes(gate_id)? as u32,
                 sess.tape(),
                 pool[&ids_key].as_ref(),
                 n_used,
-                up_w as usize,
-                shared_wup,
+                gate_w as usize,
+                shared_wgate,
                 xb,
                 false,
-                pool[ubuf].as_ref(),
+                pool[&gbuf].as_ref(),
                 ne,
-                nff,
+                gu_width,
                 rows,
                 active_mask,
             );
-        }
-    }
-    if *weight_before {
-        rec2.moe_weight_scale(pool[&gbuf].as_ref(), pool[&wts].as_ref(), n_slots, gu_width);
-        if let Some(ubuf) = &ubuf {
-            rec2.moe_weight_scale(pool[ubuf].as_ref(), pool[&wts].as_ref(), n_slots, nff);
-        }
-    }
-    match &ubuf {
-        Some(ubuf) => match act {
-            Activation::Silu => rec2.silu_mul(
-                pool[&gbuf].as_ref(),
-                pool[ubuf].as_ref(),
-                pool[&abuf].as_ref(),
-                n_act,
-                *swiglu_clamp,
-            ),
-            Activation::Sigmoid => rec2.mul_sigmoid(
-                pool[&gbuf].as_ref(),
-                pool[ubuf].as_ref(),
-                pool[&abuf].as_ref(),
-                n_act,
-                0,
-                0,
-                0,
-            ),
-            Activation::Gelu => rec2.gelu_mul_off(
-                pool[&gbuf].as_ref(),
-                pool[ubuf].as_ref(),
-                0,
-                0,
-                nff,
-                0,
-                nff,
-                0,
-                pool[&abuf].as_ref(),
-                n_act,
-            ),
-        },
-        // Fused: `gbuf` is [n_slots, 2*nff] gate|up rows; the fused activation kernels split it
-        // (gate half first, up half second per row — `Op::GatedActFused`'s convention), exactly
-        // like the resident small-m fused arm.
-        None => match act {
-            Activation::Silu => rec2.silu_mul_fused(
-                pool[&gbuf].as_ref(),
-                pool[&abuf].as_ref(),
-                n_slots,
-                nff,
-                *swiglu_clamp,
-            ),
-            Activation::Gelu => rec2.gelu_mul_fused(
-                pool[&gbuf].as_ref(),
-                pool[&abuf].as_ref(),
-                n_slots,
-                nff,
-                *swiglu_clamp,
-            ),
-            Activation::Sigmoid => {
-                return Err(be(
-                    "vulkan adapter: fused_gate_up paged MoeFfn Sigmoid unsupported",
-                ))
+            if let Some(ubuf) = &ubuf {
+                linear_paged_maybe_shared(
+                    rec2,
+                    udt,
+                    sess.arena_addr(up_id)?,
+                    sess.slot_bytes(up_id)? as u32,
+                    sess.tape(),
+                    pool[&ids_key].as_ref(),
+                    n_used,
+                    up_w as usize,
+                    shared_wup,
+                    xb,
+                    false,
+                    pool[ubuf].as_ref(),
+                    ne,
+                    nff,
+                    rows,
+                    active_mask,
+                );
             }
-        },
+        }
+        if *weight_before {
+            rec2.moe_weight_scale(pool[&gbuf].as_ref(), pool[&wts].as_ref(), n_slots, gu_width);
+            if let Some(ubuf) = &ubuf {
+                rec2.moe_weight_scale(pool[ubuf].as_ref(), pool[&wts].as_ref(), n_slots, nff);
+            }
+        }
+        match &ubuf {
+            Some(ubuf) => match act {
+                Activation::Silu => rec2.silu_mul(
+                    pool[&gbuf].as_ref(),
+                    pool[ubuf].as_ref(),
+                    pool[&abuf].as_ref(),
+                    n_act,
+                    *swiglu_clamp,
+                ),
+                Activation::Sigmoid => rec2.mul_sigmoid(
+                    pool[&gbuf].as_ref(),
+                    pool[ubuf].as_ref(),
+                    pool[&abuf].as_ref(),
+                    n_act,
+                    0,
+                    0,
+                    0,
+                ),
+                Activation::Gelu => rec2.gelu_mul_off(
+                    pool[&gbuf].as_ref(),
+                    pool[ubuf].as_ref(),
+                    0,
+                    0,
+                    nff,
+                    0,
+                    nff,
+                    0,
+                    pool[&abuf].as_ref(),
+                    n_act,
+                ),
+            },
+            // Fused: `gbuf` is [n_slots, 2*nff] gate|up rows; the fused activation kernels split it
+            // (gate half first, up half second per row — `Op::GatedActFused`'s convention), exactly
+            // like the resident small-m fused arm.
+            None => match act {
+                Activation::Silu => rec2.silu_mul_fused(
+                    pool[&gbuf].as_ref(),
+                    pool[&abuf].as_ref(),
+                    n_slots,
+                    nff,
+                    *swiglu_clamp,
+                ),
+                Activation::Gelu => rec2.gelu_mul_fused(
+                    pool[&gbuf].as_ref(),
+                    pool[&abuf].as_ref(),
+                    n_slots,
+                    nff,
+                    *swiglu_clamp,
+                ),
+                Activation::Sigmoid => {
+                    return Err(be(
+                        "vulkan adapter: fused_gate_up paged MoeFfn Sigmoid unsupported",
+                    ))
+                }
+            },
+        }
     }
     let down_w = if let Some(window) = down_w {
         window

--- a/crates/infr-vulkan/src/adapter.rs
+++ b/crates/infr-vulkan/src/adapter.rs
@@ -2648,15 +2648,24 @@ fn lower_op(
             ratio,
             row_elems,
         } => {
+            let kdt = graph.desc(*k_cache).dtype;
+            let vdt = graph.desc(*v_cache).dtype;
+            let k_q8 = kdt == infr_core::DType::Q8_0;
+            let v_q8 = vdt == infr_core::DType::Q8_0;
+            let supported = |dt| matches!(dt, infr_core::DType::F16 | infr_core::DType::Q8_0);
             if *ratio == 0
                 || *tail >= *ratio
                 || *selected_blocks > *complete_blocks
                 || *row_elems == 0
                 || !row_elems.is_multiple_of(2)
+                || ((k_q8 || v_q8) && !row_elems.is_multiple_of(32))
+                || !supported(kdt)
+                || !supported(vdt)
             {
                 return Err(be(format!(
                     "vulkan Op::QsaGather invalid geometry: selected={selected_blocks} \
-                     complete={complete_blocks} tail={tail} ratio={ratio} row_elems={row_elems}"
+                     complete={complete_blocks} tail={tail} ratio={ratio} row_elems={row_elems} \
+                     k_dtype={kdt:?} v_dtype={vdt:?}"
                 )));
             }
             rec.qsa_gather(
@@ -2670,6 +2679,10 @@ fn lower_op(
                 *tail,
                 *ratio,
                 *row_elems,
+                k_q8,
+                v_q8,
+                graph.desc(*k_cache).numel() as u32,
+                graph.desc(*v_cache).numel() as u32,
             );
         }
         Op::QsaBatchAttention {
@@ -2691,6 +2704,7 @@ fn lower_op(
             let first_blocks = first_visible / *ratio.max(&1);
             let kdt = graph.desc(*k_cache).dtype;
             let vdt = graph.desc(*v_cache).dtype;
+            let supported = |dt| matches!(dt, infr_core::DType::F16 | infr_core::DType::Q8_0);
             if *rows == 0
                 || *rows > *kv_len
                 || *n_head == 0
@@ -2702,11 +2716,11 @@ fn lower_op(
                 || *top_blocks > first_blocks
                 || *top_blocks > 512
                 || graph.desc(*q).dtype != infr_core::DType::F16
-                || kdt != infr_core::DType::F16
-                || vdt != infr_core::DType::F16
+                || !supported(kdt)
+                || !supported(vdt)
             {
                 return Err(be(format!(
-                    "vulkan Op::QsaBatchAttention requires F16 q/k/v, rows<=kv_len, \
+                    "vulkan Op::QsaBatchAttention requires F16 q, F16/Q8_0 k/v, rows<=kv_len, \
                      head_dim=128/256, n_head divisible by n_kv, ratio>0 and \
                      0<top_blocks<=first complete blocks; \
                      got rows={rows} kv_len={kv_len} n_head={n_head} n_kv={n_kv} \
@@ -2728,6 +2742,10 @@ fn lower_op(
                 *top_blocks,
                 *ratio,
                 *scale,
+                kdt == infr_core::DType::Q8_0,
+                vdt == infr_core::DType::Q8_0,
+                graph.desc(*k_cache).numel() as u32,
+                graph.desc(*v_cache).numel() as u32,
             );
         }
         // Fused per-head RMSNorm + RoPE. Peephole (see `kv_write_peephole`): a QkNormRope whose dst

--- a/crates/infr-vulkan/src/gemm.rs
+++ b/crates/infr-vulkan/src/gemm.rs
@@ -599,12 +599,14 @@ pub(crate) fn native_idm_sg_paged_build_spv(
         (Iq3S, 2, true) => v!("native_idm_iq3s_sg2_paged_sg16"),
         (Iq3S, 4, true) => v!("native_idm_iq3s_sg4_paged_sg16"),
         (Iq3S, 8, true) => v!("native_idm_iq3s_sg8_paged_sg16"),
+        (Iq2Xs, 8, false) => v!("native_idm_iq2xs_sg8_paged"),
+        (Iq2Xs, 8, true) => v!("native_idm_iq2xs_sg8_paged_sg16"),
         _ => None,
     }
 }
 
-/// Subgroup+NR twin of [`native_idm_paged_shared_build_spv`]. Only Q5_K/Q6_K have an enrolled
-/// subgroup down-projection path; IQ4_XS stays on the tree kernel.
+/// Subgroup+NR twin of [`native_idm_paged_shared_build_spv`]. Q5_K/Q6_K cover the established
+/// down-projection band; IQ2_XS covers Qwen3.8's measured gate/up shape. IQ4_XS stays on tree.
 pub(crate) fn native_idm_sg_paged_shared_build_spv(
     dtype: infr_core::DType,
     nr: u32,
@@ -635,6 +637,8 @@ pub(crate) fn native_idm_sg_paged_shared_build_spv(
         (Q5K, 2, true) => v!("native_idm_q5k_sg2_paged_shexp_sg16"),
         (Q5K, 4, true) => v!("native_idm_q5k_sg4_paged_shexp_sg16"),
         (Q5K, 8, true) => v!("native_idm_q5k_sg8_paged_shexp_sg16"),
+        (Iq2Xs, 8, false) => v!("native_idm_iq2xs_sg8_paged_shexp"),
+        (Iq2Xs, 8, true) => v!("native_idm_iq2xs_sg8_paged_shexp_sg16"),
         _ => None,
     }
 }

--- a/crates/infr-vulkan/src/gemm.rs
+++ b/crates/infr-vulkan/src/gemm.rs
@@ -3244,11 +3244,19 @@ pub(crate) fn qsa_indexer_topk_spv() -> &'static [u32] {
         )))
     })
 }
-#[cfg_attr(infr_profile, infr_prof::instrument)]
-pub(crate) fn qsa_gather_spv() -> &'static [u32] {
-    static S: OnceLock<Vec<u32>> = OnceLock::new();
-    S.get_or_init(|| spv_words(include_bytes!(concat!(env!("OUT_DIR"), "/qsa_gather.spv"))))
+macro_rules! qsa_spv {
+    ($f:ident, $name:literal) => {
+        #[cfg_attr(infr_profile, infr_prof::instrument)]
+        pub(crate) fn $f() -> &'static [u32] {
+            static S: OnceLock<Vec<u32>> = OnceLock::new();
+            S.get_or_init(|| {
+                spv_words(include_bytes!(concat!(env!("OUT_DIR"), "/", $name, ".spv")))
+            })
+        }
+    };
 }
+qsa_spv!(qsa_gather_spv, "qsa_gather");
+qsa_spv!(qsa_attention_batch_spv, "qsa_attention_batch");
 /// SPIR-V for Ling KDA recurrent attention.
 #[cfg_attr(infr_profile, infr_prof::instrument)]
 pub(crate) fn kda_spv() -> &'static [u32] {

--- a/crates/infr-vulkan/src/gemm.rs
+++ b/crates/infr-vulkan/src/gemm.rs
@@ -3256,7 +3256,13 @@ macro_rules! qsa_spv {
     };
 }
 qsa_spv!(qsa_gather_spv, "qsa_gather");
+qsa_spv!(qsa_gather_kq8_spv, "qsa_gather_kq8");
+qsa_spv!(qsa_gather_vq8_spv, "qsa_gather_vq8");
+qsa_spv!(qsa_gather_q8_spv, "qsa_gather_q8");
 qsa_spv!(qsa_attention_batch_spv, "qsa_attention_batch");
+qsa_spv!(qsa_attention_batch_kq8_spv, "qsa_attention_batch_kq8");
+qsa_spv!(qsa_attention_batch_vq8_spv, "qsa_attention_batch_vq8");
+qsa_spv!(qsa_attention_batch_q8_spv, "qsa_attention_batch_q8");
 /// SPIR-V for Ling KDA recurrent attention.
 #[cfg_attr(infr_profile, infr_prof::instrument)]
 pub(crate) fn kda_spv() -> &'static [u32] {

--- a/crates/infr-vulkan/src/gemm.rs
+++ b/crates/infr-vulkan/src/gemm.rs
@@ -642,6 +642,16 @@ pub(crate) fn native_idm_sg_paged_shared_build_spv(
         _ => None,
     }
 }
+
+/// Qwen3.8's fused paged IQ2_XS gate+up GEMV and SwiGLU decode kernel.
+pub(crate) fn native_id_swiglu_iq2xs_spv() -> &'static [u32] {
+    const BYTES: &[u8] = include_bytes!(concat!(
+        env!("OUT_DIR"),
+        "/native_id_swiglu_iq2xs_sg8_paged.spv"
+    ));
+    static S: OnceLock<Vec<u32>> = OnceLock::new();
+    S.get_or_init(|| spv_words(BYTES))
+}
 /// The id-indexed int8 Q4_K decode GEMV; the sole weight build for this variant. Env-gated
 /// measurement entry ([`crate::recorder::Recorder::linear_mmv_id_multi_q4k`]) + parity tests.
 #[cfg_attr(infr_profile, infr_prof::instrument)]

--- a/crates/infr-vulkan/src/pager.rs
+++ b/crates/infr-vulkan/src/pager.rs
@@ -1760,6 +1760,11 @@ pub use infr_core::pager::ring_bytes;
 // whose byte count is not evenly divisible by its slot count from giving every later region a
 // pathologically misaligned base address.
 const RING_REGION_ALIGN: usize = 256;
+const MIN_LUT_TAPE_WORDS: usize = 64 * 1024;
+
+fn moe_lut_tape_words(n_blocks: usize) -> usize {
+    MIN_LUT_TAPE_WORDS.max(n_blocks.saturating_mul(3))
+}
 
 fn ring_region_bytes(total: usize, slots: usize, min_slot_bytes: usize) -> usize {
     debug_assert!(slots >= 2);
@@ -1858,10 +1863,10 @@ impl MoePagerSession {
                 exchange_slot,
             });
         }
-        // One graph's windows = paged layers x roles x n_expert addresses. 64k entries (512 KiB)
-        // leaves an order of magnitude of headroom; `lut_window` hard-errors
-        // on overflow rather than wrapping into a region an in-flight segment may still read.
-        let tape_words = 64 * 1024;
+        // One graph's windows can name every paged layer once for each of Gate/Up/Down. Keep the
+        // historical 64k floor for smaller models, while 512-expert models size to their actual
+        // global role space instead of overflowing at the 129th window.
+        let tape_words = moe_lut_tape_words(layout.n_blocks);
         let tape = vk.alloc_uninit(tape_words * 8, BufferUsage::Staging)?;
         Ok(Self {
             load_reservation,
@@ -2565,7 +2570,7 @@ impl MoePagerSession {
                 .prefill_placement
                 .get(&bank_id)
                 .ok_or_else(|| be("moe pager: async layer bank has no Prefill placement"))?;
-            let (_, _source_pool, source) = self
+            let (_, source_pool, source) = self
                 .sources
                 .get(&bank_id)
                 .ok_or_else(|| be("moe pager: async layer bank source disappeared"))?;
@@ -2582,7 +2587,9 @@ impl MoePagerSession {
                     len: src.len(),
                 }));
             } else {
-                let host = self.pools[bank_placement.pool]
+                // Prefill may pack this bank into a different GPU arena pool, but its block
+                // descriptors remain registered in the original size-class host pool.
+                let host = self.pools[*source_pool]
                     .host
                     .as_ref()
                     .ok_or_else(|| be("moe pager: tiered Prefill bank has no host reader"))?;
@@ -3551,6 +3558,12 @@ mod tests {
     fn validate_pager_dims_accepts_valid() {
         assert!(validate_pager_dims(1, 4).is_ok());
         assert!(validate_pager_dims(238, 13 << 20).is_ok());
+    }
+
+    #[test]
+    fn moe_lut_tape_covers_three_windows_per_global_expert_block() {
+        assert_eq!(moe_lut_tape_words(24 * 256), MIN_LUT_TAPE_WORDS);
+        assert_eq!(moe_lut_tape_words(48 * 512), 48 * 512 * 3);
     }
 
     #[test]

--- a/crates/infr-vulkan/src/recorder.rs
+++ b/crates/infr-vulkan/src/recorder.rs
@@ -8296,6 +8296,7 @@ impl<'a> Recorder<'a> {
         k_norm: &dyn Buffer,
         scores: &dyn Buffer,
         dst: &dyn Buffer,
+        rows: u32,
         kv_len: u32,
         n_head: u32,
         head_dim: u32,
@@ -8311,17 +8312,18 @@ impl<'a> Recorder<'a> {
             "qsa_indexer_score",
             crate::gemm::qsa_indexer_score_spv(),
             4,
-            32,
+            36,
         );
-        let mut push = [0u8; 32];
-        push[0..4].copy_from_slice(&kv_len.to_ne_bytes());
-        push[4..8].copy_from_slice(&n_head.to_ne_bytes());
-        push[8..12].copy_from_slice(&head_dim.to_ne_bytes());
-        push[12..16].copy_from_slice(&ratio.to_ne_bytes());
-        push[16..20].copy_from_slice(&rope_dim.to_ne_bytes());
-        push[20..24].copy_from_slice(&theta.to_ne_bytes());
-        push[24..28].copy_from_slice(&eps.to_ne_bytes());
-        push[28..32].copy_from_slice(&scale.to_ne_bytes());
+        let mut push = [0u8; 36];
+        push[0..4].copy_from_slice(&rows.to_ne_bytes());
+        push[4..8].copy_from_slice(&kv_len.to_ne_bytes());
+        push[8..12].copy_from_slice(&n_head.to_ne_bytes());
+        push[12..16].copy_from_slice(&head_dim.to_ne_bytes());
+        push[16..20].copy_from_slice(&ratio.to_ne_bytes());
+        push[20..24].copy_from_slice(&rope_dim.to_ne_bytes());
+        push[24..28].copy_from_slice(&theta.to_ne_bytes());
+        push[28..32].copy_from_slice(&eps.to_ne_bytes());
+        push[32..36].copy_from_slice(&scale.to_ne_bytes());
         self.dispatch_wide(
             score_k,
             &[
@@ -8332,24 +8334,82 @@ impl<'a> Recorder<'a> {
             ],
             1,
             &push,
-            blocks,
+            rows.saturating_mul(blocks),
         );
 
         let topk_k = self.be.kernel(
             "qsa_indexer_topk",
             crate::gemm::qsa_indexer_topk_spv(),
             2,
-            8,
+            20,
         );
-        let mut topk_push = [0u8; 8];
+        let mut topk_push = [0u8; 20];
         topk_push[0..4].copy_from_slice(&blocks.to_ne_bytes());
         topk_push[4..8].copy_from_slice(&top_blocks.to_ne_bytes());
+        topk_push[8..12].copy_from_slice(&rows.to_ne_bytes());
+        topk_push[12..16].copy_from_slice(&kv_len.to_ne_bytes());
+        topk_push[16..20].copy_from_slice(&ratio.to_ne_bytes());
         self.dispatch(
             topk_k,
             &[Self::vkb(scores), Self::vkb(dst)],
             1,
             &topk_push,
+            rows,
+        );
+    }
+
+    #[allow(clippy::too_many_arguments)]
+    pub fn qsa_attention_batch(
+        &self,
+        q: &dyn Buffer,
+        k: &dyn Buffer,
+        v: &dyn Buffer,
+        indices: &dyn Buffer,
+        dst: &dyn Buffer,
+        rows: u32,
+        kv_len: u32,
+        n_head: u32,
+        n_kv: u32,
+        head_dim: u32,
+        top_blocks: u32,
+        ratio: u32,
+        scale: f32,
+    ) {
+        let kernel = self.be.kernel_sg(
+            "qsa_attention_batch",
+            crate::gemm::qsa_attention_batch_spv(),
+            5,
+            32,
+            32,
+        );
+        let mut push = [0u8; 32];
+        for (i, value) in [
+            rows,
+            kv_len,
+            n_head,
+            n_kv,
+            head_dim,
+            top_blocks,
+            ratio,
+            scale.to_bits(),
+        ]
+        .into_iter()
+        .enumerate()
+        {
+            push[i * 4..i * 4 + 4].copy_from_slice(&value.to_ne_bytes());
+        }
+        self.dispatch_wide(
+            kernel,
+            &[
+                Self::vkb(q),
+                Self::vkb(k),
+                Self::vkb(v),
+                Self::vkb(indices),
+                Self::vkb(dst),
+            ],
             1,
+            &push,
+            rows.saturating_mul(n_head),
         );
     }
 

--- a/crates/infr-vulkan/src/recorder.rs
+++ b/crates/infr-vulkan/src/recorder.rs
@@ -10217,6 +10217,61 @@ impl<'a> Recorder<'a> {
         self.dispatch_wide(k, &bufs, 1, &push, (n_used * out_f) as u32);
     }
 
+    /// Fused paged IQ2_XS gate+up GEMV and SwiGLU for Qwen3.8 decode.
+    #[allow(clippy::too_many_arguments)]
+    pub fn linear_native_id_swiglu_iq2xs_paged(
+        &self,
+        ids: &dyn Buffer,
+        n_used: usize,
+        gate_lut: &dyn Buffer,
+        gate_lut_base: usize,
+        up_lut: &dyn Buffer,
+        up_lut_base: usize,
+        x: &dyn Buffer,
+        y: &dyn Buffer,
+        in_f: usize,
+        out_f: usize,
+        rows: usize,
+        active_mask: u32,
+    ) {
+        let k = self.be.kernel_sg(
+            "native_id_swiglu_iq2xs_sg8_paged",
+            crate::gemm::native_id_swiglu_iq2xs_spv(),
+            5,
+            28,
+            32,
+        );
+        let mut push = [0u8; 28];
+        for (i, value) in [
+            in_f as u32,
+            out_f as u32,
+            n_used as u32,
+            gate_lut_base as u32,
+            up_lut_base as u32,
+            rows as u32,
+            active_mask,
+        ]
+        .into_iter()
+        .enumerate()
+        {
+            push[i * 4..i * 4 + 4].copy_from_slice(&value.to_ne_bytes());
+        }
+        let groups = (rows * n_used * out_f.div_ceil(8)) as u32;
+        self.dispatch_wide(
+            k,
+            &[
+                Self::vkb(x),
+                Self::vkb(ids),
+                Self::vkb(gate_lut),
+                Self::vkb(up_lut),
+                Self::vkb(y),
+            ],
+            1,
+            &push,
+            groups,
+        );
+    }
+
     /// Quantize f32 activations `a` [m,k] → int8 `qa` [m,k] + per-32-block f16 `dact`/`sact`
     /// ([m, k/32]) for the dp4a mmq matmul. (Pass 1 of mmq, reusable standalone.)
     pub fn quant_q8(

--- a/crates/infr-vulkan/src/recorder.rs
+++ b/crates/infr-vulkan/src/recorder.rs
@@ -245,6 +245,12 @@ fn native_id_sg_choice(
     // (codebook in an L2-resident BUFFER instead of per-workgroup LDS) is the real fix for the
     // gate/up shape and is NOT what this tier does; ablating grid_init() outright measured
     // native_idm_iq2s 49.8 → 23.3ms, i.e. ~50ms of a 505ms decode still on the table.
+    // Qwen3.8's 2560x640 IQ2_XS gate/up shape wins with NR=8: its 4 KiB codebook is staged once
+    // for eight output rows instead of once per row. Keep the enrollment exact; IQ2_S's similar
+    // low-output shape regresses on this tier, and no other IQ2_XS geometry has been measured.
+    if dtype == Iq2Xs {
+        return (in_f == 2560 && out_f == 640).then_some(8);
+    }
     if !matches!(dtype, Q6K | Q5K | Iq3S) {
         return None;
     }
@@ -11476,6 +11482,9 @@ mod tests {
         for dt in [D::Q5K, D::Q6K, D::Iq3S] {
             assert_eq!(native_id_sg_choice(dt, 512, 2048, k), Some(2), "{dt:?}");
         }
+        assert_eq!(native_id_sg_choice(D::Iq2Xs, 2560, 640, k), Some(8));
+        assert_eq!(native_id_sg_choice(D::Iq2Xs, 2560, 641, k), None);
+        assert_eq!(native_id_sg_choice(D::Iq2Xs, 2048, 640, k), None);
         for dt in [D::Q4K, D::Iq4Nl, D::Iq2S] {
             assert_eq!(native_id_sg_choice(dt, 512, 2048, k), None, "{dt:?}");
         }

--- a/crates/infr-vulkan/src/recorder.rs
+++ b/crates/infr-vulkan/src/recorder.rs
@@ -8374,15 +8374,31 @@ impl<'a> Recorder<'a> {
         top_blocks: u32,
         ratio: u32,
         scale: f32,
+        k_q8: bool,
+        v_q8: bool,
+        kcap: u32,
+        vcap: u32,
     ) {
-        let kernel = self.be.kernel_sg(
-            "qsa_attention_batch",
-            crate::gemm::qsa_attention_batch_spv(),
-            5,
-            32,
-            32,
-        );
-        let mut push = [0u8; 32];
+        let (name, spv) = match (k_q8, v_q8) {
+            (false, false) => (
+                "qsa_attention_batch",
+                crate::gemm::qsa_attention_batch_spv(),
+            ),
+            (true, false) => (
+                "qsa_attention_batch_kq8",
+                crate::gemm::qsa_attention_batch_kq8_spv(),
+            ),
+            (false, true) => (
+                "qsa_attention_batch_vq8",
+                crate::gemm::qsa_attention_batch_vq8_spv(),
+            ),
+            (true, true) => (
+                "qsa_attention_batch_q8",
+                crate::gemm::qsa_attention_batch_q8_spv(),
+            ),
+        };
+        let kernel = self.be.kernel_sg(name, spv, 5, 40, 32);
+        let mut push = [0u8; 40];
         for (i, value) in [
             rows,
             kv_len,
@@ -8392,6 +8408,8 @@ impl<'a> Recorder<'a> {
             top_blocks,
             ratio,
             scale.to_bits(),
+            kcap,
+            vcap,
         ]
         .into_iter()
         .enumerate()
@@ -8426,19 +8444,29 @@ impl<'a> Recorder<'a> {
         tail: u32,
         ratio: u32,
         row_elems: u32,
+        k_q8: bool,
+        v_q8: bool,
+        kcap: u32,
+        vcap: u32,
     ) {
         let row_pairs = row_elems / 2;
         let total_pairs = (selected * ratio + tail) * row_pairs;
-        let kernel = self
-            .be
-            .kernel("qsa_gather", crate::gemm::qsa_gather_spv(), 5, 24);
-        let mut push = [0u8; 24];
+        let (name, spv) = match (k_q8, v_q8) {
+            (false, false) => ("qsa_gather", crate::gemm::qsa_gather_spv()),
+            (true, false) => ("qsa_gather_kq8", crate::gemm::qsa_gather_kq8_spv()),
+            (false, true) => ("qsa_gather_vq8", crate::gemm::qsa_gather_vq8_spv()),
+            (true, true) => ("qsa_gather_q8", crate::gemm::qsa_gather_q8_spv()),
+        };
+        let kernel = self.be.kernel(name, spv, 5, 32);
+        let mut push = [0u8; 32];
         push[0..4].copy_from_slice(&selected.to_ne_bytes());
         push[4..8].copy_from_slice(&complete.to_ne_bytes());
         push[8..12].copy_from_slice(&tail.to_ne_bytes());
         push[12..16].copy_from_slice(&ratio.to_ne_bytes());
         push[16..20].copy_from_slice(&row_pairs.to_ne_bytes());
         push[20..24].copy_from_slice(&total_pairs.to_ne_bytes());
+        push[24..28].copy_from_slice(&kcap.to_ne_bytes());
+        push[28..32].copy_from_slice(&vcap.to_ne_bytes());
         self.dispatch(
             kernel,
             &[

--- a/crates/infr-vulkan/tests/moe_id_gemv_new_formats_parity.rs
+++ b/crates/infr-vulkan/tests/moe_id_gemv_new_formats_parity.rs
@@ -492,6 +492,110 @@ fn paged_sg_id_gemv_matches_host() {
     }
 }
 
+/// Qwen3.8's decode fast path resolves two independent paged IQ2_XS banks, computes gate/up
+/// GEMVs, and writes SwiGLU directly. Keep a host reference here so LUT placement, activation,
+/// and masked routed slots stay covered independently of full-model generation tests.
+#[test]
+#[ignore = "requires a Vulkan GPU"]
+fn paged_iq2xs_fused_swiglu_matches_host() {
+    let Ok(be) = VulkanBackend::new() else {
+        eprintln!("skip: no Vulkan device");
+        return;
+    };
+    let dt = DType::Iq2Xs;
+    let (in_f, out_f, n_expert) = (256usize, 16usize, 4usize);
+    let stride = in_f * out_f;
+    let (epb, bpb) = block_geom(dt);
+    let stride_bytes = stride / epb * bpb;
+    let gate_banks: Vec<Vec<u8>> = (0..n_expert)
+        .map(|e| synth_bank(dt, stride, 0x6a7e ^ ((e as u64) << 32)))
+        .collect();
+    let up_banks: Vec<Vec<u8>> = (0..n_expert)
+        .map(|e| synth_bank(dt, stride, 0x7570 ^ ((e as u64) << 32)))
+        .collect();
+    let host_gate: Vec<Vec<f32>> = gate_banks
+        .iter()
+        .map(|b| infr_gguf::dequant::dequant_block(dt, b).unwrap())
+        .collect();
+    let host_up: Vec<Vec<f32>> = up_banks
+        .iter()
+        .map(|b| infr_gguf::dequant::dequant_block(dt, b).unwrap())
+        .collect();
+
+    let ids = [3u32, 0, 2];
+    let ids_buf = be.alloc(ids.len() * 4, BufferUsage::Activations).unwrap();
+    be.upload(ids_buf.as_ref(), bytemuck::cast_slice(&ids))
+        .unwrap();
+    let x: Vec<f32> = (0..in_f)
+        .map(|i| ((i % 19) as f32 - 9.0) * 0.0125)
+        .collect();
+    let x_buf = be.alloc(in_f * 4, BufferUsage::Activations).unwrap();
+    be.upload(x_buf.as_ref(), bytemuck::cast_slice(&x)).unwrap();
+
+    let mut gate_pager = GpuPager::new(&be, n_expert, ids.len(), stride_bytes).unwrap();
+    let mut up_pager = GpuPager::new(&be, n_expert, ids.len(), stride_bytes).unwrap();
+    let staging = be.alloc_uninit(stride_bytes, BufferUsage::Staging).unwrap();
+    // The load order deliberately differs from logical expert order.
+    for &eid in &[0u32, 2, 3] {
+        gate_pager
+            .ensure_resident(&be, staging.as_ref(), eid, &gate_banks[eid as usize])
+            .unwrap();
+        up_pager
+            .ensure_resident(&be, staging.as_ref(), eid, &up_banks[eid as usize])
+            .unwrap();
+    }
+    gate_pager.flush_lut(&be).unwrap();
+    up_pager.flush_lut(&be).unwrap();
+
+    let y = be
+        .alloc(ids.len() * out_f * 4, BufferUsage::Activations)
+        .unwrap();
+    let active_mask = 0b101u32;
+    let sentinel = vec![-17.0f32; ids.len() * out_f];
+    be.upload(y.as_ref(), bytemuck::cast_slice(&sentinel))
+        .unwrap();
+    let rec = be.recorder().unwrap();
+    rec.linear_native_id_swiglu_iq2xs_paged(
+        ids_buf.as_ref(),
+        ids.len(),
+        gate_pager.lut_buffer(),
+        0,
+        up_pager.lut_buffer(),
+        0,
+        x_buf.as_ref(),
+        y.as_ref(),
+        in_f,
+        out_f,
+        1,
+        active_mask,
+    );
+    rec.finish().unwrap();
+
+    let mut out = vec![0u8; ids.len() * out_f * 4];
+    be.download(y.as_ref(), &mut out).unwrap();
+    let got: &[f32] = bytemuck::cast_slice(&out);
+    for (slot, &eid) in ids.iter().enumerate() {
+        let slot_out = &got[slot * out_f..(slot + 1) * out_f];
+        if active_mask & (1 << slot) == 0 {
+            assert!(slot_out.iter().all(|&v| v == -17.0));
+            continue;
+        }
+        let gate = host_gemv(&host_gate[eid as usize], &x, in_f, out_f);
+        let up = host_gemv(&host_up[eid as usize], &x, in_f, out_f);
+        let want: Vec<f32> = gate
+            .iter()
+            .zip(&up)
+            .map(|(&g, &u)| g / (1.0 + (-g).exp()) * u)
+            .collect();
+        assert_close(
+            dt,
+            &format!("paged fused SwiGLU expert {eid}"),
+            slot_out,
+            &want,
+        );
+    }
+}
+
 /// Backlog B39: the native-block kernels walk K as `nsub = in_f / 32` whole 32-element sub-blocks,
 /// so an expert bank narrower than 32 ran ZERO iterations — and since the GEMV writes its
 /// accumulator unconditionally, `linear_native_id_multi` completed cleanly and stored an exact

--- a/crates/infr-vulkan/tests/moe_id_gemv_new_formats_parity.rs
+++ b/crates/infr-vulkan/tests/moe_id_gemv_new_formats_parity.rs
@@ -373,6 +373,89 @@ fn new_dtype_id_gemv_paged_matches_host_under_eviction_churn() {
     }
 }
 
+/// Qwen3.8 Q2 batched Prefill falls back to this shape-general paged id-GEMV because IQ2_XS has
+/// no dp4a MMQ kernel. Distinct inputs and expert ids per row verify the `(row, slot)` flattening.
+#[test]
+#[ignore = "requires a Vulkan GPU"]
+fn paged_iq2xs_multirow_matches_host() {
+    let Ok(be) = VulkanBackend::new() else {
+        eprintln!("skip: no Vulkan device");
+        return;
+    };
+    let (rows, n_used, n_expert) = (3usize, 2usize, 4usize);
+    let (in_f, out_f) = (256usize, 8usize);
+    let stride = in_f * out_f;
+    let dt = DType::Iq2Xs;
+    let (epb, bpb) = block_geom(dt);
+    let stride_bytes = stride / epb * bpb;
+    let banks: Vec<Vec<u8>> = (0..n_expert)
+        .map(|e| synth_bank(dt, stride, 0x38ba_7c11 ^ ((e as u64) << 32)))
+        .collect();
+    let host: Vec<Vec<f32>> = banks
+        .iter()
+        .map(|b| infr_gguf::dequant::dequant_block(dt, b).unwrap())
+        .collect();
+    let x: Vec<f32> = (0..rows * in_f)
+        .map(|i| ((i * 17 + i / in_f * 23) % 61) as f32 * 0.0125 - 0.35)
+        .collect();
+    let ids = [0u32, 2, 3, 1, 2, 0];
+
+    let x_buf = be.alloc(x.len() * 4, BufferUsage::Activations).unwrap();
+    let ids_buf = be.alloc(ids.len() * 4, BufferUsage::Activations).unwrap();
+    be.upload(x_buf.as_ref(), bytemuck::cast_slice(&x)).unwrap();
+    be.upload(ids_buf.as_ref(), bytemuck::cast_slice(&ids))
+        .unwrap();
+    let mut pager = GpuPager::new(&be, n_expert, n_expert, stride_bytes).unwrap();
+    let staging = be.alloc_uninit(stride_bytes, BufferUsage::Staging).unwrap();
+    for eid in 0..n_expert as u32 {
+        pager
+            .ensure_resident(&be, staging.as_ref(), eid, &banks[eid as usize])
+            .unwrap();
+    }
+    pager.flush_lut(&be).unwrap();
+    let y = be
+        .alloc(rows * n_used * out_f * 4, BufferUsage::Activations)
+        .unwrap();
+
+    let rec = be.recorder().unwrap();
+    rec.linear_native_id_multi_paged(
+        dt,
+        pager.arena_addr(),
+        pager.slot_bytes() as u32,
+        pager.lut_buffer(),
+        ids_buf.as_ref(),
+        n_used,
+        0,
+        x_buf.as_ref(),
+        false,
+        y.as_ref(),
+        in_f,
+        out_f,
+        rows,
+        u32::MAX,
+    );
+    rec.finish().unwrap();
+
+    let mut out = vec![0u8; rows * n_used * out_f * 4];
+    be.download(y.as_ref(), &mut out).unwrap();
+    let got: &[f32] = bytemuck::cast_slice(&out);
+    for (pair, &eid) in ids.iter().enumerate() {
+        let row = pair / n_used;
+        let want = host_gemv(
+            &host[eid as usize],
+            &x[row * in_f..(row + 1) * in_f],
+            in_f,
+            out_f,
+        );
+        assert_close(
+            dt,
+            &format!("paged multirow row {row} expert {eid}"),
+            &got[pair * out_f..(pair + 1) * out_f],
+            &want,
+        );
+    }
+}
+
 /// The paged decode route must use the same reassociation-tolerant subgroup+NR kernels as the
 /// resident route for the three deliberately enrolled heavy formats. `out_f=2048` enters the
 /// default SG band; `rows=1` is decode. Scrambled ids and a nontrivial LUT placement prove the

--- a/crates/infr-vulkan/tests/qsa_parity.rs
+++ b/crates/infr-vulkan/tests/qsa_parity.rs
@@ -160,6 +160,35 @@ fn qsa_index_and_gather_match_reference() {
     }
     assert_eq!(got_k, want_k);
     assert_eq!(got_v, want_v);
+
+    // Equal scores exercise the secondary key: the earliest block indices must win exactly as
+    // they did in the repeated-max implementation.
+    be.upload(q.as_ref(), &vec![0; qb.len()]).unwrap();
+    be.upload(raw.as_ref(), &vec![0; rawb.len()]).unwrap();
+    let rec = be.recorder().unwrap();
+    rec.qsa_indexer(
+        q.as_ref(),
+        raw.as_ref(),
+        nw.as_ref(),
+        scores.as_ref(),
+        ids.as_ref(),
+        1,
+        kv_len as u32,
+        nh as u32,
+        hd as u32,
+        top as u32,
+        ratio as u32,
+        rope_dim as u32,
+        theta,
+        eps,
+        scale,
+    );
+    rec.finish().unwrap();
+    be.download(ids.as_ref(), &mut ib).unwrap();
+    assert_eq!(
+        bytemuck::cast_slice::<u8, u32>(&ib),
+        &(0..top as u32).collect::<Vec<_>>()
+    );
 }
 
 #[test]

--- a/crates/infr-vulkan/tests/qsa_parity.rs
+++ b/crates/infr-vulkan/tests/qsa_parity.rs
@@ -80,7 +80,7 @@ fn qsa_index_and_gather_match_reference() {
     be.upload(raw.as_ref(), &rawb).unwrap();
     be.upload(nw.as_ref(), bytemuck::cast_slice(&norm)).unwrap();
 
-    let row = 16usize;
+    let row = 32usize;
     let kvals: Vec<f32> = (0..kv_len * row).map(|i| i as f32 * 0.001).collect();
     let vvals: Vec<f32> = (0..kv_len * row).map(|i| -1.0 - i as f32 * 0.001).collect();
     let kb = f16_bytes(&kvals);
@@ -126,6 +126,10 @@ fn qsa_index_and_gather_match_reference() {
         2,
         ratio as u32,
         row as u32,
+        false,
+        false,
+        0,
+        0,
     );
     rec.finish().unwrap();
 
@@ -160,6 +164,39 @@ fn qsa_index_and_gather_match_reference() {
     }
     assert_eq!(got_k, want_k);
     assert_eq!(got_v, want_v);
+
+    let cap = kv_len * row;
+    let q8_bytes = (cap / 32 * 34).next_multiple_of(4);
+    let kq = be.alloc(q8_bytes, BufferUsage::KvCache).unwrap();
+    let vq = be.alloc(q8_bytes, BufferUsage::KvCache).unwrap();
+    let rec = be.recorder().unwrap();
+    rec.store_q8(k.as_ref(), kq.as_ref(), cap, 0, cap, true, 0);
+    rec.store_q8(v.as_ref(), vq.as_ref(), cap, 0, cap, true, 0);
+    rec.qsa_gather(
+        kq.as_ref(),
+        vq.as_ref(),
+        ids.as_ref(),
+        kd.as_ref(),
+        vd.as_ref(),
+        top as u32,
+        blocks as u32,
+        2,
+        ratio as u32,
+        row as u32,
+        true,
+        true,
+        cap as u32,
+        cap as u32,
+    );
+    rec.finish().unwrap();
+    be.download(kd.as_ref(), &mut got_k).unwrap();
+    be.download(vd.as_ref(), &mut got_v).unwrap();
+    for (name, got, want) in [("K", &got_k, &want_k), ("V", &got_v, &want_v)] {
+        for i in 0..out_rows * row {
+            let err = (h(got, i) - h(want, i)).abs();
+            assert!(err < 0.03, "Q8 {name} gather elem {i}: err {err}");
+        }
+    }
 
     // Equal scores exercise the secondary key: the earliest block indices must win exactly as
     // they did in the repeated-max implementation.
@@ -363,6 +400,10 @@ fn qsa_batched_rows_match_causal_reference() {
         top as u32,
         ratio as u32,
         attn_scale,
+        false,
+        false,
+        0,
+        0,
     );
     rec.finish().unwrap();
 
@@ -379,6 +420,46 @@ fn qsa_batched_rows_match_causal_reference() {
         assert!(
             (got - want).abs() < 3e-3,
             "output {i}: got {got}, want {want}"
+        );
+    }
+
+    let cap = kv_len * n_kv * attn_hd;
+    let q8_bytes = (cap / 32 * 34).next_multiple_of(4);
+    let kq = be.alloc(q8_bytes, BufferUsage::KvCache).unwrap();
+    let vq = be.alloc(q8_bytes, BufferUsage::KvCache).unwrap();
+    let q8_out = be
+        .alloc(want_out.len() * 4, BufferUsage::Activations)
+        .unwrap();
+    let rec = be.recorder().unwrap();
+    rec.store_q8(k.as_ref(), kq.as_ref(), cap, 0, cap, true, 0);
+    rec.store_q8(v.as_ref(), vq.as_ref(), cap, 0, cap, true, 0);
+    rec.qsa_attention_batch(
+        attn_q.as_ref(),
+        kq.as_ref(),
+        vq.as_ref(),
+        ids.as_ref(),
+        q8_out.as_ref(),
+        rows as u32,
+        kv_len as u32,
+        n_head as u32,
+        n_kv as u32,
+        attn_hd as u32,
+        top as u32,
+        ratio as u32,
+        attn_scale,
+        true,
+        true,
+        cap as u32,
+        cap as u32,
+    );
+    rec.finish().unwrap();
+    let mut q8_out_bytes = vec![0u8; want_out.len() * 4];
+    be.download(q8_out.as_ref(), &mut q8_out_bytes).unwrap();
+    let q8_out = bytemuck::cast_slice::<u8, f32>(&q8_out_bytes);
+    for (i, (&got, &want)) in q8_out.iter().zip(&want_out).enumerate() {
+        assert!(
+            (got - want).abs() < 0.02,
+            "Q8 output {i}: got {got}, want {want}"
         );
     }
 }

--- a/crates/infr-vulkan/tests/qsa_parity.rs
+++ b/crates/infr-vulkan/tests/qsa_parity.rs
@@ -104,6 +104,7 @@ fn qsa_index_and_gather_match_reference() {
         nw.as_ref(),
         scores.as_ref(),
         ids.as_ref(),
+        1,
         kv_len as u32,
         nh as u32,
         hd as u32,
@@ -159,4 +160,196 @@ fn qsa_index_and_gather_match_reference() {
     }
     assert_eq!(got_k, want_k);
     assert_eq!(got_v, want_v);
+}
+
+#[test]
+fn qsa_batched_rows_match_causal_reference() {
+    let Ok(be) = VulkanBackend::new() else {
+        eprintln!("skip: no Vulkan device");
+        return;
+    };
+    let (rows, ratio, index_hd, index_heads, rope_dim, top) =
+        (3usize, 4usize, 128usize, 4usize, 64usize, 3usize);
+    let (n_head, n_kv, attn_hd) = (4usize, 2usize, 256usize);
+    let kv_len = 26usize;
+    let max_blocks = kv_len / ratio;
+    let theta = 10_000.0f32;
+    let eps = 1e-6f32;
+    let index_scale = 1.0 / (index_hd as f32).sqrt();
+    let attn_scale = 1.0 / (attn_hd as f32).sqrt();
+
+    let index_qv: Vec<f32> = (0..rows * index_heads * index_hd)
+        .map(|i| ((i * 37 + 11) % 101) as f32 / 65.0 - 0.75)
+        .collect();
+    let rawv: Vec<f32> = (0..kv_len * index_hd)
+        .map(|i| ((i * 53 + 7) % 127) as f32 / 75.0 - 0.8)
+        .collect();
+    let norm: Vec<f32> = (0..index_hd)
+        .map(|i| 0.75 + (i % 17) as f32 * 0.01)
+        .collect();
+    let index_qb = f16_bytes(&index_qv);
+    let rawb = f16_bytes(&rawv);
+
+    let mut want_ids = Vec::with_capacity(rows * top);
+    let mut key = vec![0.0f32; index_hd];
+    for row in 0..rows {
+        let visible = kv_len - rows + row + 1;
+        let blocks = visible / ratio;
+        let mut scores = vec![0.0f32; blocks];
+        for (block, score) in scores.iter_mut().enumerate() {
+            for d in 0..index_hd {
+                key[d] = (0..ratio)
+                    .map(|r| h(&rawb, (block * ratio + r) * index_hd + d))
+                    .sum::<f32>()
+                    / ratio as f32;
+                key[d] = half::f16::from_f32(key[d]).to_f32();
+            }
+            let inv = (key.iter().map(|v| v * v).sum::<f32>() / index_hd as f32 + eps)
+                .sqrt()
+                .recip();
+            for d in 0..index_hd {
+                key[d] *= inv * norm[d];
+            }
+            for pair in 0..rope_dim / 2 {
+                let d = 2 * pair;
+                let angle =
+                    (block * ratio) as f32 * theta.powf(-((2 * pair) as f32) / rope_dim as f32);
+                let (sin, cos) = angle.sin_cos();
+                let (a, b) = (key[d], key[d + 1]);
+                key[d] = a * cos - b * sin;
+                key[d + 1] = a * sin + b * cos;
+            }
+            let qbase = row * index_heads * index_hd;
+            for head in 0..index_heads {
+                let dot = (0..index_hd)
+                    .map(|d| h(&index_qb, qbase + head * index_hd + d) * key[d])
+                    .sum::<f32>();
+                *score += dot.max(0.0) * index_scale;
+            }
+        }
+        let mut rank: Vec<usize> = (0..blocks).collect();
+        rank.sort_unstable_by(|&a, &b| scores[b].total_cmp(&scores[a]).then_with(|| a.cmp(&b)));
+        rank.truncate(top);
+        rank.sort_unstable();
+        want_ids.extend(rank.into_iter().map(|i| i as u32));
+    }
+
+    let attn_qv: Vec<f32> = (0..rows * n_head * attn_hd)
+        .map(|i| ((i * 29 + 19) % 113) as f32 / 90.0 - 0.6)
+        .collect();
+    let kvals: Vec<f32> = (0..kv_len * n_kv * attn_hd)
+        .map(|i| ((i * 43 + 5) % 109) as f32 / 85.0 - 0.65)
+        .collect();
+    let vvals: Vec<f32> = (0..kv_len * n_kv * attn_hd)
+        .map(|i| ((i * 31 + 23) % 103) as f32 / 80.0 - 0.6)
+        .collect();
+    let attn_qb = f16_bytes(&attn_qv);
+    let kb = f16_bytes(&kvals);
+    let vb = f16_bytes(&vvals);
+
+    let mut want_out = vec![0.0f32; rows * n_head * attn_hd];
+    for row in 0..rows {
+        let visible = kv_len - rows + row + 1;
+        let complete = visible / ratio;
+        let tail = visible % ratio;
+        let mut source_rows = Vec::with_capacity(top * ratio + tail);
+        for &block in &want_ids[row * top..(row + 1) * top] {
+            source_rows.extend(block as usize * ratio..(block as usize + 1) * ratio);
+        }
+        source_rows.extend(complete * ratio..complete * ratio + tail);
+        for head in 0..n_head {
+            let kv_head = head / (n_head / n_kv);
+            let qbase = (row * n_head + head) * attn_hd;
+            let mut logits = Vec::with_capacity(source_rows.len());
+            for &src_row in &source_rows {
+                let kbase = (src_row * n_kv + kv_head) * attn_hd;
+                logits.push(
+                    (0..attn_hd)
+                        .map(|d| h(&attn_qb, qbase + d) * h(&kb, kbase + d))
+                        .sum::<f32>()
+                        * attn_scale,
+                );
+            }
+            let max = logits.iter().copied().fold(f32::NEG_INFINITY, f32::max);
+            let denom = logits.iter().map(|x| (x - max).exp()).sum::<f32>();
+            for (&src_row, logit) in source_rows.iter().zip(logits) {
+                let p = (logit - max).exp() / denom;
+                let vbase = (src_row * n_kv + kv_head) * attn_hd;
+                for d in 0..attn_hd {
+                    want_out[qbase + d] += p * h(&vb, vbase + d);
+                }
+            }
+        }
+    }
+
+    let index_q = be.alloc(index_qb.len(), BufferUsage::Activations).unwrap();
+    let raw = be.alloc(rawb.len(), BufferUsage::KvCache).unwrap();
+    let nw = be.alloc(norm.len() * 4, BufferUsage::Weights).unwrap();
+    let scores = be
+        .alloc(rows * max_blocks * 4, BufferUsage::Activations)
+        .unwrap();
+    let ids = be.alloc(rows * top * 4, BufferUsage::Activations).unwrap();
+    let attn_q = be.alloc(attn_qb.len(), BufferUsage::Activations).unwrap();
+    let k = be.alloc(kb.len(), BufferUsage::KvCache).unwrap();
+    let v = be.alloc(vb.len(), BufferUsage::KvCache).unwrap();
+    let out = be
+        .alloc(want_out.len() * 4, BufferUsage::Activations)
+        .unwrap();
+    be.upload(index_q.as_ref(), &index_qb).unwrap();
+    be.upload(raw.as_ref(), &rawb).unwrap();
+    be.upload(nw.as_ref(), bytemuck::cast_slice(&norm)).unwrap();
+    be.upload(attn_q.as_ref(), &attn_qb).unwrap();
+    be.upload(k.as_ref(), &kb).unwrap();
+    be.upload(v.as_ref(), &vb).unwrap();
+
+    let rec = be.recorder().unwrap();
+    rec.qsa_indexer(
+        index_q.as_ref(),
+        raw.as_ref(),
+        nw.as_ref(),
+        scores.as_ref(),
+        ids.as_ref(),
+        rows as u32,
+        kv_len as u32,
+        index_heads as u32,
+        index_hd as u32,
+        top as u32,
+        ratio as u32,
+        rope_dim as u32,
+        theta,
+        eps,
+        index_scale,
+    );
+    rec.qsa_attention_batch(
+        attn_q.as_ref(),
+        k.as_ref(),
+        v.as_ref(),
+        ids.as_ref(),
+        out.as_ref(),
+        rows as u32,
+        kv_len as u32,
+        n_head as u32,
+        n_kv as u32,
+        attn_hd as u32,
+        top as u32,
+        ratio as u32,
+        attn_scale,
+    );
+    rec.finish().unwrap();
+
+    let mut got_ids_bytes = vec![0u8; rows * top * 4];
+    be.download(ids.as_ref(), &mut got_ids_bytes).unwrap();
+    assert_eq!(
+        bytemuck::cast_slice::<u8, u32>(&got_ids_bytes),
+        want_ids.as_slice()
+    );
+    let mut got_out_bytes = vec![0u8; want_out.len() * 4];
+    be.download(out.as_ref(), &mut got_out_bytes).unwrap();
+    let got_out = bytemuck::cast_slice::<u8, f32>(&got_out_bytes);
+    for (i, (&got, &want)) in got_out.iter().zip(&want_out).enumerate() {
+        assert!(
+            (got - want).abs() < 3e-3,
+            "output {i}: got {got}, want {want}"
+        );
+    }
 }

--- a/scripts/infr-wizard.ps1
+++ b/scripts/infr-wizard.ps1
@@ -153,7 +153,30 @@ function Read-Choice {
 
 function ConvertTo-FullPath {
     param([Parameter(Mandatory = $true)][string]$Value)
-    $value = $Value.Trim().Trim('"').Trim("'")
+    $value = $Value.Trim()
+
+    # PowerShell-aware terminals may paste a dropped file as `& 'C:\path\model.gguf'`.
+    # Read-Host returns that as plain text, so remove the call operator and paired quotes before
+    # treating it as a path. Repeating the quote pass also accepts a copied quoted path wrapped by
+    # another pair of quotes.
+    if ($value -match '^&\s*(.+)$') {
+        $value = $Matches[1].Trim()
+    }
+    while ($value.Length -ge 2) {
+        $first = $value[0]
+        $last = $value[$value.Length - 1]
+        if (($first -eq '"' -and $last -eq '"') -or ($first -eq "'" -and $last -eq "'")) {
+            $value = $value.Substring(1, $value.Length - 2).Trim()
+            continue
+        }
+        break
+    }
+
+    $uri = $null
+    if ($value.StartsWith('file:', [System.StringComparison]::OrdinalIgnoreCase) -and
+        [System.Uri]::TryCreate($value, [System.UriKind]::Absolute, [ref]$uri) -and $uri.IsFile) {
+        $value = $uri.LocalPath
+    }
     if ([System.IO.Path]::IsPathRooted($value)) {
         return [System.IO.Path]::GetFullPath($value)
     }

--- a/scripts/infr-wizard.ps1
+++ b/scripts/infr-wizard.ps1
@@ -1,6 +1,8 @@
 ﻿[CmdletBinding()]
 param(
-    [switch]$DryRun
+    [Parameter(Position = 0)][string]$InitialModelPath = '',
+    [switch]$DryRun,
+    [switch]$SkipUpdateCheck
 )
 
 $ErrorActionPreference = 'Stop'
@@ -184,6 +186,25 @@ function ConvertTo-FullPath {
 }
 
 function Select-ModelPath {
+    param([AllowEmptyString()][string]$InitialPath = '')
+
+    if (-not [string]::IsNullOrWhiteSpace($InitialPath)) {
+        try {
+            $modelPath = ConvertTo-FullPath $InitialPath
+        } catch {
+            throw "启动参数中的模型路径无效 / Invalid model path passed to the launcher: $InitialPath"
+        }
+        if (-not (Test-Path -LiteralPath $modelPath -PathType Leaf)) {
+            throw "找不到启动参数中的模型文件 / Model file passed to the launcher was not found: $modelPath"
+        }
+        if ([System.IO.Path]::GetExtension($modelPath) -ne '.gguf') {
+            throw "启动参数必须指向 GGUF 文件 / The launcher argument must point to a GGUF file: $modelPath"
+        }
+        Write-Host "`n已从启动参数选择模型 / Model selected from launcher argument" -ForegroundColor Cyan
+        Write-Host " $modelPath"
+        return $modelPath
+    }
+
     $models = [System.Collections.Generic.List[string]]::new()
     $seen = [System.Collections.Generic.HashSet[string]]::new([System.StringComparer]::OrdinalIgnoreCase)
 
@@ -312,21 +333,86 @@ function Get-ClientAddress {
     return $value
 }
 
-Clear-Host
-Write-Host 'INFR 启动向导 / INFR Launch Wizard' -ForegroundColor Green
-Write-Host '上次设置会作为默认值；直接回车即可复用。Press Enter to reuse the previous value.'
-Write-Host "程序 / Executable: $infrPath" -ForegroundColor DarkGray
+function Get-EngineVersion {
+    $output = (& $infrPath --version 2>$null | Out-String).Trim()
+    $exitCode = $LASTEXITCODE
+    if ($exitCode -eq 0 -and $output -match '(\d+\.\d+\.\d+(?:[-+][0-9A-Za-z.-]+)?)') {
+        return $Matches[1]
+    }
+    return 'unknown'
+}
+
+function ConvertTo-ComparableVersion {
+    param([Parameter(Mandatory = $true)][string]$Value)
+    if ($Value -match '(\d+)\.(\d+)\.(\d+)') {
+        return [version]::new([int]$Matches[1], [int]$Matches[2], [int]$Matches[3])
+    }
+    return $null
+}
+
+function Show-UpdateStatus {
+    param([Parameter(Mandatory = $true)][string]$CurrentVersion)
+
+    $disabled = [Environment]::GetEnvironmentVariable('MOE4ALL_NO_UPDATE_CHECK', 'Process')
+    if ($SkipUpdateCheck -or $disabled -match '^(1|true|yes|on)$') {
+        return
+    }
+    $current = ConvertTo-ComparableVersion $CurrentVersion
+    if ($null -eq $current) {
+        return
+    }
+
+    try {
+        $headers = @{
+            Accept = 'application/vnd.github+json'
+            'User-Agent' = "MoE4All-Wizard/$CurrentVersion"
+        }
+        $release = Invoke-RestMethod -Uri 'https://api.github.com/repos/Headmaster218/MoE4All/releases/latest' -Headers $headers -TimeoutSec 3 -ErrorAction Stop
+        $latestText = [string]$release.tag_name
+        $latest = ConvertTo-ComparableVersion $latestText
+        if ($null -ne $latest -and $latest -gt $current) {
+            Write-Host "发现新版本 / Update available: $latestText" -ForegroundColor Yellow
+            Write-Host ([string]$release.html_url) -ForegroundColor Cyan
+        } elseif ($null -ne $latest) {
+            Write-Host "更新检查 / Update check: v$CurrentVersion is current" -ForegroundColor DarkGray
+        }
+    } catch {
+        Write-Host '更新检查不可用，继续离线启动。Update check unavailable; continuing offline.' -ForegroundColor DarkGray
+    }
+}
 
 if (-not (Test-Path -LiteralPath $infrPath -PathType Leaf)) {
     throw "找不到 infr.exe。发布包请把 infr.exe 与 Start-INFR-Wizard.cmd 放在同一目录；源码构建请先运行 cargo build --release --locked -p infr-cli。`nExecutable not found beside the launcher or under target\release."
 }
+
+$productVersion = Get-EngineVersion
+Clear-Host
+Write-Host '============================================================' -ForegroundColor Green
+$banner = @'
+ __  __       _____ _  _     _   _ _
+|  \/  | ___ | ____| || |   / \ | | |
+| |\/| |/ _ \|  _| | || |_ / _ \| | |
+| |  | | (_) | |___|__   _/ ___ \ | |___
+|_|  |_|\___/|_____|  |_|/_/   \_\_|_____|
+'@
+
+Write-Host $banner -ForegroundColor Green
+Write-Host "  MoE4All v$productVersion" -ForegroundColor Green
+Write-Host '  Making huge MoE LLMs accessible to AMD users.'
+Write-Host '  让 A 卡用户也能在本地运行大型 MoE AI！'
+Write-Host '  John / Headmaster218  https://github.com/Headmaster218/MoE4All' -ForegroundColor DarkGray
+Write-Host '============================================================' -ForegroundColor Green
+Write-Host 'MoE4All 启动向导 / MoE4All Launch Wizard' -ForegroundColor Green
+Write-Host '上次设置会作为默认值；直接回车即可复用。Press Enter to reuse the previous value.'
+Write-Host "引擎 / Engine: $infrPath" -ForegroundColor DarkGray
+Show-UpdateStatus -CurrentVersion $productVersion
 
 $launchMode = Read-Choice -Label '你想做什么？/ What would you like to do?' -DefaultValue ([string](Get-SavedValue 'launch_mode' 'chat')) -Options @(
     [pscustomobject]@{ Key = '1'; Value = 'chat'; Label = '实时终端对话（推荐）/ Interactive terminal chat (recommended)' }
     [pscustomobject]@{ Key = '2'; Value = 'server'; Label = '启动 OpenAI 兼容 API / Start OpenAI-compatible API server' }
     [pscustomobject]@{ Key = '3'; Value = 'benchmark'; Label = '性能测试 / Benchmark' }
 )
-$modelPath = Select-ModelPath
+$modelPath = Select-ModelPath -InitialPath $InitialModelPath
 
 $setupModeDefault = 'quick'
 if ($null -ne $script:Saved) {
@@ -696,5 +782,5 @@ try {
     }
 }
 if ($null -eq $exitCode) { $exitCode = 0 }
-Write-Host "`nINFR 退出码 / exit code: $exitCode" -ForegroundColor $(if ($exitCode -eq 0) { 'Green' } else { 'Red' })
+Write-Host "`nMoE4All / infr 退出码 / exit code: $exitCode" -ForegroundColor $(if ($exitCode -eq 0) { 'Green' } else { 'Red' })
 exit $exitCode

--- a/scripts/package-windows.ps1
+++ b/scripts/package-windows.ps1
@@ -43,7 +43,7 @@ if ($Version -notmatch '^\d+\.\d+\.\d+(?:[-+][0-9A-Za-z.-]+)?$') {
 $outputFullPath = Resolve-RepoPath $OutputDirectory
 New-Item -ItemType Directory -Path $outputFullPath -Force | Out-Null
 
-$packageName = "infr-windows-x86_64-$Version"
+$packageName = "MoE4All-Windows-x86_64-v$Version"
 $stagingPath = Join-Path $outputFullPath $packageName
 $outputPrefix = $outputFullPath.TrimEnd([System.IO.Path]::DirectorySeparatorChar) + [System.IO.Path]::DirectorySeparatorChar
 if (-not $stagingPath.StartsWith($outputPrefix, [System.StringComparison]::OrdinalIgnoreCase)) {

--- a/scripts/smoke-windows-package.ps1
+++ b/scripts/smoke-windows-package.ps1
@@ -75,7 +75,7 @@ if ($dependencyOutput -match '(?i)\b(?:vcruntime|msvcp|concrt)[^\s]*\.dll\b|\bap
 $wizardSource = Get-Content -LiteralPath $wizardPath -Raw -Encoding UTF8
 [void][scriptblock]::Create($wizardSource)
 
-$modelPath = Join-Path $PackageRoot 'ci-smoke-model.gguf'
+$modelPath = Join-Path $PackageRoot 'ci smoke model.gguf'
 [System.IO.File]::WriteAllBytes($modelPath, [byte[]]::new(0))
 $dataDirectory = Join-Path $PackageRoot 'gui-data'
 New-Item -ItemType Directory -Path $dataDirectory -Force | Out-Null
@@ -83,7 +83,8 @@ New-Item -ItemType Directory -Path $dataDirectory -Force | Out-Null
 function Invoke-WizardDryRun {
     param(
         [Parameter(Mandatory = $true)][string]$Mode,
-        [Parameter(Mandatory = $true)][string]$ExpectedCommand
+        [Parameter(Mandatory = $true)][string]$ExpectedCommand,
+        [string]$ModelSelection = ''
     )
 
     $state = [ordered]@{
@@ -120,7 +121,11 @@ function Invoke-WizardDryRun {
     $process = [System.Diagnostics.Process]::Start($processInfo)
     $stdoutTask = $process.StandardOutput.ReadToEndAsync()
     $stderrTask = $process.StandardError.ReadToEndAsync()
-    for ($i = 0; $i -lt 32; $i++) {
+    # Keep the saved launch mode, then exercise the same Read-Host model prompt used for
+    # Explorer/terminal drag-and-drop. Remaining blank answers retain the saved quick settings.
+    $process.StandardInput.WriteLine('')
+    $process.StandardInput.WriteLine($ModelSelection)
+    for ($i = 0; $i -lt 30; $i++) {
         $process.StandardInput.WriteLine('')
     }
     $process.StandardInput.WriteLine('x')
@@ -143,8 +148,10 @@ function Invoke-WizardDryRun {
     }
 }
 
-Invoke-WizardDryRun -Mode 'chat' -ExpectedCommand 'run'
-Invoke-WizardDryRun -Mode 'server' -ExpectedCommand 'serve'
+$quotedModelPath = '"' + $modelPath + '"'
+$powerShellDrop = "& '$modelPath'"
+Invoke-WizardDryRun -Mode 'chat' -ExpectedCommand 'run' -ModelSelection $quotedModelPath
+Invoke-WizardDryRun -Mode 'server' -ExpectedCommand 'serve' -ModelSelection $powerShellDrop
 Invoke-WizardDryRun -Mode 'benchmark' -ExpectedCommand 'bench'
 
 Remove-Item -LiteralPath $modelPath -Force

--- a/scripts/smoke-windows-package.ps1
+++ b/scripts/smoke-windows-package.ps1
@@ -1,7 +1,8 @@
 [CmdletBinding()]
 param(
     [Parameter(Mandatory = $true)][string]$PackageRoot,
-    [string]$ExpectedVersion = ''
+    [string]$ExpectedVersion = '',
+    [switch]$SkipDependencyCheck
 )
 
 $ErrorActionPreference = 'Stop'
@@ -12,7 +13,18 @@ $binaryPath = Join-Path $PackageRoot 'infr.exe'
 $wizardPath = Join-Path $PackageRoot 'scripts\infr-wizard.ps1'
 $launcherPath = Join-Path $PackageRoot 'Start-INFR-Wizard.cmd'
 
-foreach ($requiredPath in @($binaryPath, $wizardPath, $launcherPath)) {
+$requiredPaths = @(
+    $binaryPath
+    $wizardPath
+    $launcherPath
+    (Join-Path $PackageRoot 'README.md')
+    (Join-Path $PackageRoot 'README_EN.md')
+    (Join-Path $PackageRoot 'GETTING_STARTED.md')
+    (Join-Path $PackageRoot 'LICENSE')
+    (Join-Path $PackageRoot 'LICENSE-MIT')
+    (Join-Path $PackageRoot 'NOTICE')
+)
+foreach ($requiredPath in $requiredPaths) {
     if (-not (Test-Path -LiteralPath $requiredPath -PathType Leaf)) {
         throw "Required package file is missing: $requiredPath"
     }
@@ -40,35 +52,37 @@ foreach ($command in @('run', 'serve', 'bench')) {
 
 # A release archive must not require users to install the Visual C++ runtime.
 # Vulkan is loaded dynamically from the GPU driver and does not appear here.
-$dependencyOutput = ''
-$dumpbin = Get-Command 'dumpbin.exe' -ErrorAction SilentlyContinue
-if ($null -eq $dumpbin) {
-    $programFilesX86 = [Environment]::GetFolderPath('ProgramFilesX86')
-    $vswherePath = Join-Path $programFilesX86 'Microsoft Visual Studio\Installer\vswhere.exe'
-    if (Test-Path -LiteralPath $vswherePath -PathType Leaf) {
-        $visualStudioPath = (& $vswherePath -latest -products * -requires Microsoft.VisualStudio.Component.VC.Tools.x86.x64 -property installationPath | Select-Object -First 1)
-        if ($visualStudioPath) {
-            $dumpbin = Get-ChildItem -LiteralPath (Join-Path $visualStudioPath 'VC\Tools\MSVC') -Filter 'dumpbin.exe' -Recurse |
-                Where-Object { $_.FullName -match 'Hostx64[\\/]x64[\\/]dumpbin\.exe$' } |
-                Sort-Object FullName -Descending |
-                Select-Object -First 1
+if (-not $SkipDependencyCheck) {
+    $dependencyOutput = ''
+    $dumpbin = Get-Command 'dumpbin.exe' -ErrorAction SilentlyContinue
+    if ($null -eq $dumpbin) {
+        $programFilesX86 = [Environment]::GetFolderPath('ProgramFilesX86')
+        $vswherePath = Join-Path $programFilesX86 'Microsoft Visual Studio\Installer\vswhere.exe'
+        if (Test-Path -LiteralPath $vswherePath -PathType Leaf) {
+            $visualStudioPath = (& $vswherePath -latest -products * -requires Microsoft.VisualStudio.Component.VC.Tools.x86.x64 -property installationPath | Select-Object -First 1)
+            if ($visualStudioPath) {
+                $dumpbin = Get-ChildItem -LiteralPath (Join-Path $visualStudioPath 'VC\Tools\MSVC') -Filter 'dumpbin.exe' -Recurse |
+                    Where-Object { $_.FullName -match 'Hostx64[\\/]x64[\\/]dumpbin\.exe$' } |
+                    Sort-Object FullName -Descending |
+                    Select-Object -First 1
+            }
         }
     }
-}
-if ($null -ne $dumpbin) {
-    $dumpbinPath = if ($dumpbin -is [System.IO.FileInfo]) { $dumpbin.FullName } else { $dumpbin.Source }
-    $dependencyOutput = & $dumpbinPath /dependents $binaryPath 2>&1 | Out-String
-    if ($LASTEXITCODE -ne 0) { throw "dumpbin failed with exit code $LASTEXITCODE" }
-} else {
-    $objdump = Get-Command 'objdump.exe' -ErrorAction SilentlyContinue
-    if ($null -eq $objdump) {
-        throw 'Neither dumpbin.exe nor objdump.exe is available to verify release dependencies.'
+    if ($null -ne $dumpbin) {
+        $dumpbinPath = if ($dumpbin -is [System.IO.FileInfo]) { $dumpbin.FullName } else { $dumpbin.Source }
+        $dependencyOutput = & $dumpbinPath /dependents $binaryPath 2>&1 | Out-String
+        if ($LASTEXITCODE -ne 0) { throw "dumpbin failed with exit code $LASTEXITCODE" }
+    } else {
+        $objdump = Get-Command 'objdump.exe' -ErrorAction SilentlyContinue
+        if ($null -eq $objdump) {
+            throw 'Neither dumpbin.exe nor objdump.exe is available to verify release dependencies.'
+        }
+        $dependencyOutput = & $objdump.Source -p $binaryPath 2>&1 | Out-String
+        if ($LASTEXITCODE -ne 0) { throw "objdump failed with exit code $LASTEXITCODE" }
     }
-    $dependencyOutput = & $objdump.Source -p $binaryPath 2>&1 | Out-String
-    if ($LASTEXITCODE -ne 0) { throw "objdump failed with exit code $LASTEXITCODE" }
-}
-if ($dependencyOutput -match '(?i)\b(?:vcruntime|msvcp|concrt)[^\s]*\.dll\b|\bapi-ms-win-crt-[^\s]*\.dll\b') {
-    throw "Release executable still depends on the Visual C++ runtime.`n$dependencyOutput"
+    if ($dependencyOutput -match '(?i)\b(?:vcruntime|msvcp|concrt)[^\s]*\.dll\b|\bapi-ms-win-crt-[^\s]*\.dll\b') {
+        throw "Release executable still depends on the Visual C++ runtime.`n$dependencyOutput"
+    }
 }
 
 # Parse with Windows PowerShell before exercising the CMD wrapper that end users double-click.
@@ -84,7 +98,8 @@ function Invoke-WizardDryRun {
     param(
         [Parameter(Mandatory = $true)][string]$Mode,
         [Parameter(Mandatory = $true)][string]$ExpectedCommand,
-        [string]$ModelSelection = ''
+        [string]$ModelSelection = '',
+        [switch]$PassModelArgument
     )
 
     $state = [ordered]@{
@@ -116,15 +131,22 @@ function Invoke-WizardDryRun {
     $processInfo.RedirectStandardError = $true
     $processInfo.WorkingDirectory = $PackageRoot
     $quotedLauncher = $launcherPath.Replace('"', '""')
-    $processInfo.Arguments = "/d /s /c `"`"$quotedLauncher`" -DryRun`""
+    $launcherArguments = '-DryRun -SkipUpdateCheck'
+    if ($PassModelArgument) {
+        $quotedModelArgument = $modelPath.Replace('"', '""')
+        $launcherArguments += " `"$quotedModelArgument`""
+    }
+    $processInfo.Arguments = "/d /s /c `"`"$quotedLauncher`" $launcherArguments`""
 
     $process = [System.Diagnostics.Process]::Start($processInfo)
     $stdoutTask = $process.StandardOutput.ReadToEndAsync()
     $stderrTask = $process.StandardError.ReadToEndAsync()
-    # Keep the saved launch mode, then exercise the same Read-Host model prompt used for
-    # Explorer/terminal drag-and-drop. Remaining blank answers retain the saved quick settings.
+    # Keep the saved launch mode. Without a launcher argument, exercise the same Read-Host model
+    # prompt used when a path is pasted into an already-open terminal.
     $process.StandardInput.WriteLine('')
-    $process.StandardInput.WriteLine($ModelSelection)
+    if (-not $PassModelArgument) {
+        $process.StandardInput.WriteLine($ModelSelection)
+    }
     for ($i = 0; $i -lt 30; $i++) {
         $process.StandardInput.WriteLine('')
     }
@@ -143,16 +165,25 @@ function Invoke-WizardDryRun {
     if ($stdout -notmatch 'DryRun: command was not started\.') {
         throw "Wizard $Mode did not reach DryRun completion.`n$stdout`n$stderr"
     }
+    if ($stdout -notmatch [regex]::Escape("MoE4All v$ExpectedVersion")) {
+        throw "Wizard $Mode did not display the expected MoE4All version banner.`n$stdout"
+    }
     if ($stdout -notmatch "\s$ExpectedCommand\s") {
         throw "Wizard $Mode did not generate the expected '$ExpectedCommand' command.`n$stdout"
+    }
+    if ($stdout -notmatch [regex]::Escape($modelPath)) {
+        throw "Wizard $Mode did not preserve the model path.`n$stdout"
+    }
+    if ($PassModelArgument -and $stdout -notmatch 'Model selected from launcher argument') {
+        throw "Wizard $Mode did not accept the model passed by CMD/drag-and-drop.`n$stdout"
     }
 }
 
 $quotedModelPath = '"' + $modelPath + '"'
 $powerShellDrop = "& '$modelPath'"
-Invoke-WizardDryRun -Mode 'chat' -ExpectedCommand 'run' -ModelSelection $quotedModelPath
+Invoke-WizardDryRun -Mode 'chat' -ExpectedCommand 'run' -PassModelArgument
 Invoke-WizardDryRun -Mode 'server' -ExpectedCommand 'serve' -ModelSelection $powerShellDrop
-Invoke-WizardDryRun -Mode 'benchmark' -ExpectedCommand 'bench'
+Invoke-WizardDryRun -Mode 'benchmark' -ExpectedCommand 'bench' -ModelSelection $quotedModelPath
 
 Remove-Item -LiteralPath $modelPath -Force
 Remove-Item -LiteralPath $dataDirectory -Recurse -Force


### PR DESCRIPTION
主要更新
- Qwen3.8 Flash Next 新增 Q8 KV Cache，并修复高深度分页 Prefill 稳定性问题。
- QSA Top-K 改用 radix selection，批量执行 QSA 与 PLE Prefill。
- 融合分页 SwiGLU，降低 IQ2_XS codebook staging 开销。
- Benchmark 使用更多样的 MoE 路由 prompt，并更新 Qwen3.8 性能矩阵。
- CMD 支持直接拖入 GGUF 文件。
- Windows 发布包正式采用 MoE4All 品牌，增加 Banner、版本显示和自动更新检查。
- 发布包改名为 MoE4All-Windows-x86_64-v0.3.0.zip，内部仍保留 infr.exe 以兼容现有命令和脚本。