### PR TITLE
MoE4All v0.5.0：动态 KV Cache、默认 Q8 KV 与 Qwen3.8 Prefill 性能修复

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,39 @@ The format follows [Keep a Changelog](https://keepachangelog.com/en/1.1.0/).
 
 ## [Unreleased]
 
+## [0.5.0] - 2026-08-30
+
+### Highlights
+
+- **Qwen KV state now grows in 32K-token segments on Vulkan.** Compatible Qwen3.5/Qwen3.6 and
+  Qwen3.8-Flash-Next sessions allocate Q8 K/V capacity as context crosses each segment boundary
+  instead of reserving the complete configured window at startup. Qwen3.8's QSA index-key state
+  follows the same elastic allocation model.
+- **Compatible Vulkan sessions now default to Q8_0 K/V.** Explicit `kv.type_k` and `kv.type_v`
+  choices remain authoritative; layouts that cannot use Q8_0 continue to fall back to F16.
+
+### Changed
+
+- Chunk-major prefill is again the production default for resident and streamed models.
+  Layer-major execution remains available only through the explicit `paging.layer_major=true`
+  diagnostic override.
+- Memory planning, runtime allocation, cache reporting, synthetic-depth setup, and session cloning
+  now resolve the same effective Vulkan K/V format and segmented layout.
+
+### Fixed
+
+- Qwen3.8 QSA planes are allocated from their segmented arena instead of retaining an unintended
+  flat context-sized allocation.
+- Automatic K/V budgeting no longer prices F16 while the Vulkan runner actually allocates Q8_0,
+  preventing inconsistent context limits and VRAM accounting.
+- Segmented K/V address lowering now handles reads, writes, Q8 dequantization, attention, and QSA
+  gather/index operations across 32K boundaries.
+
+### Known limitations
+
+- Elastic segmented growth currently applies to coupled Q8_0 K/V on supported Qwen Vulkan paths.
+  Explicit F16 or mixed K/V formats retain the established flat-allocation behavior.
+
 ## [0.4.0] - 2026-08-29
 
 ### Highlights

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1124,7 +1124,7 @@ dependencies = [
 
 [[package]]
 name = "infr-chat"
-version = "0.4.0"
+version = "0.5.0"
 dependencies = [
  "chrono",
  "infr-core",
@@ -1139,7 +1139,7 @@ dependencies = [
 
 [[package]]
 name = "infr-cli"
-version = "0.4.0"
+version = "0.5.0"
 dependencies = [
  "anyhow",
  "clap",
@@ -1163,7 +1163,7 @@ dependencies = [
 
 [[package]]
 name = "infr-core"
-version = "0.4.0"
+version = "0.5.0"
 dependencies = [
  "bytemuck",
  "half",
@@ -1181,7 +1181,7 @@ dependencies = [
 
 [[package]]
 name = "infr-cpu"
-version = "0.4.0"
+version = "0.5.0"
 dependencies = [
  "anyhow",
  "bytemuck",
@@ -1197,7 +1197,7 @@ dependencies = [
 
 [[package]]
 name = "infr-embedding"
-version = "0.4.0"
+version = "0.5.0"
 dependencies = [
  "anyhow",
  "bytemuck",
@@ -1214,7 +1214,7 @@ dependencies = [
 
 [[package]]
 name = "infr-engine"
-version = "0.4.0"
+version = "0.5.0"
 dependencies = [
  "anyhow",
  "infr-chat",
@@ -1228,7 +1228,7 @@ dependencies = [
 
 [[package]]
 name = "infr-gguf"
-version = "0.4.0"
+version = "0.5.0"
 dependencies = [
  "anyhow",
  "bytemuck",
@@ -1244,7 +1244,7 @@ dependencies = [
 
 [[package]]
 name = "infr-gui"
-version = "0.4.0"
+version = "0.5.0"
 dependencies = [
  "anyhow",
  "axum",
@@ -1264,7 +1264,7 @@ dependencies = [
 
 [[package]]
 name = "infr-hub"
-version = "0.4.0"
+version = "0.5.0"
 dependencies = [
  "dirs",
  "indicatif",
@@ -1281,7 +1281,7 @@ dependencies = [
 
 [[package]]
 name = "infr-llama"
-version = "0.4.0"
+version = "0.5.0"
 dependencies = [
  "anyhow",
  "bytemuck",
@@ -1304,7 +1304,7 @@ dependencies = [
 
 [[package]]
 name = "infr-metal"
-version = "0.4.0"
+version = "0.5.0"
 dependencies = [
  "bytemuck",
  "half",
@@ -1320,7 +1320,7 @@ dependencies = [
 
 [[package]]
 name = "infr-prof"
-version = "0.4.0"
+version = "0.5.0"
 dependencies = [
  "proc-macro2",
  "quote",
@@ -1329,11 +1329,11 @@ dependencies = [
 
 [[package]]
 name = "infr-prof-rt"
-version = "0.4.0"
+version = "0.5.0"
 
 [[package]]
 name = "infr-server"
-version = "0.4.0"
+version = "0.5.0"
 dependencies = [
  "anyhow",
  "axum",
@@ -1352,7 +1352,7 @@ dependencies = [
 
 [[package]]
 name = "infr-testkit"
-version = "0.4.0"
+version = "0.5.0"
 dependencies = [
  "bytemuck",
  "half",
@@ -1362,7 +1362,7 @@ dependencies = [
 
 [[package]]
 name = "infr-vulkan"
-version = "0.4.0"
+version = "0.5.0"
 dependencies = [
  "ash",
  "bytemuck",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -20,7 +20,7 @@ members = [
 ]
 
 [workspace.package]
-version = "0.4.0"
+version = "0.5.0"
 edition = "2021"
 license = "Apache-2.0"
 repository = "https://github.com/Headmaster218/MoE4All"

--- a/crates/infr-cli/src/main.rs
+++ b/crates/infr-cli/src/main.rs
@@ -1383,7 +1383,7 @@ fn cmd_run(
 fn read_line_interruptible(line: &mut String) -> anyhow::Result<usize> {
     #[cfg(not(unix))]
     {
-        return Ok(std::io::stdin().read_line(line)?);
+        Ok(std::io::stdin().read_line(line)?)
     }
     #[cfg(unix)]
     {

--- a/crates/infr-core/src/backend.rs
+++ b/crates/infr-core/src/backend.rs
@@ -523,9 +523,23 @@ pub trait Backend: Send + Sync {
         Ok(None)
     }
 
+    /// Whether segmented KV allocations can currently borrow from a pre-reserved elastic pool.
+    /// This is runtime state, not a static device capability: Vulkan returns true only after the
+    /// paged-MoE arena has been established.
+    fn segmented_kv_available(&self) -> bool {
+        false
+    }
+
     /// Ensure that `buffer` owns at least `segments` physical KV segments. Backends that returned
     /// `Some` from [`Backend::alloc_segmented_kv`] must accept that buffer here.
     fn ensure_segmented_kv(&self, _buffer: &dyn Buffer, _segments: usize) -> Result<()> {
+        Err(crate::error::Error::backend(
+            "segmented KV is not supported by this backend",
+        ))
+    }
+    /// Clear every committed physical segment. Used by synthetic-depth benchmarks, whose logical
+    /// history must be deterministic even though it was not produced by a real prefill.
+    fn clear_segmented_kv(&self, _buffer: &dyn Buffer) -> Result<()> {
         Err(crate::error::Error::backend(
             "segmented KV is not supported by this backend",
         ))

--- a/crates/infr-core/src/backend.rs
+++ b/crates/infr-core/src/backend.rs
@@ -415,6 +415,19 @@ pub trait Buffer: Send + Sync {
     }
 }
 
+/// Geometry of a logically contiguous KV buffer whose physical storage is committed in fixed
+/// segments. `logical_bytes` preserves the graph-visible full-context extent; `segment_bytes`
+/// and `max_segments` describe the bounded physical backing grown on demand.
+#[derive(Clone, Copy, Debug, PartialEq, Eq)]
+pub struct SegmentedKvSpec {
+    pub logical_bytes: usize,
+    pub segment_bytes: usize,
+    /// Logical tensor elements represented by one segment. This excludes format-local side data
+    /// such as the planar Q8 scale plane and is always a power of two for the 32K Qwen geometry.
+    pub segment_elements: usize,
+    pub max_segments: usize,
+}
+
 /// A compiled, ready-to-run graph (pipelines + command buffers for Vulkan, an op schedule for CPU).
 pub trait Plan: Send + Sync {
     /// Downcast hook so a backend can recover its concrete plan type from a `&dyn Plan`.
@@ -502,6 +515,20 @@ pub trait Backend: Send + Sync {
     /// the perf win.
     fn alloc_uninit(&self, bytes: usize, usage: BufferUsage) -> Result<Box<dyn Buffer>> {
         self.alloc(bytes, usage)
+    }
+
+    /// Allocate a lazily committed KV buffer when this backend supports segmented device
+    /// addressing. `None` keeps the caller on its existing flat-buffer path.
+    fn alloc_segmented_kv(&self, _spec: SegmentedKvSpec) -> Result<Option<Box<dyn Buffer>>> {
+        Ok(None)
+    }
+
+    /// Ensure that `buffer` owns at least `segments` physical KV segments. Backends that returned
+    /// `Some` from [`Backend::alloc_segmented_kv`] must accept that buffer here.
+    fn ensure_segmented_kv(&self, _buffer: &dyn Buffer, _segments: usize) -> Result<()> {
+        Err(crate::error::Error::backend(
+            "segmented KV is not supported by this backend",
+        ))
     }
     fn upload(&self, dst: &dyn Buffer, src: &[u8]) -> Result<()>;
     fn download(&self, src: &dyn Buffer, dst: &mut [u8]) -> Result<()>;

--- a/crates/infr-core/src/budget.rs
+++ b/crates/infr-core/src/budget.rs
@@ -573,7 +573,7 @@ mod tests {
             unified_vram_room(
                 24 * GIB,
                 12 * GIB,
-                1 * GIB,
+                GIB,
                 Some(SizeSpec::Percent(0.90)),
                 Some(SizeSpec::Bytes(2 * GIB)),
             ),

--- a/crates/infr-core/src/config/env.rs
+++ b/crates/infr-core/src/config/env.rs
@@ -187,6 +187,7 @@ pub fn parse(get: Get) -> Result<PartialConfig, ConfigError> {
     p.kv.force_q8 = presence(get, "INFR_KV_Q8");
     p.kv.slots = num_pos(get, "INFR_KV_SLOTS");
     p.kv.ring = presence_inv(get, "INFR_NO_KV_RING");
+    p.kv.dynamic = presence_inv(get, "INFR_NO_DYNAMIC_KV");
     p.kv.inline_decode = presence(get, "INFR_KV_INLINE");
     p.kv.coopmat_bda = presence(get, "INFR_KV_COOPMAT_BDA");
     p.kv.overflow = flag(get, "INFR_KV_OVERFLOW");

--- a/crates/infr-core/src/config/env.rs
+++ b/crates/infr-core/src/config/env.rs
@@ -205,8 +205,8 @@ pub fn parse(get: Get) -> Result<PartialConfig, ConfigError> {
     p.paging.host_dma = presence_inv(get, "INFR_NO_HOST_DMA");
     p.paging.stats = presence(get, "INFR_PAGER_STATS");
     p.paging.trace = opt_path(get, "INFR_PAGER_TRACE");
-    // Tri-state: "0" ⇒ force chunk-major, any other value ⇒ force layer-major, unset ⇒ decide
-    // from the placement (see `PagingCfg::layer_major`).
+    // Tri-state syntax retained for compatibility: "0" keeps chunk-major, any other value forces
+    // layer-major, and unset uses the chunk-major default (see `PagingCfg::layer_major`).
     p.paging.layer_major = get("INFR_LAYER_MAJOR").map(|s| Some(s != "0"));
 
     // ── kernels.vulkan ───────────────────────────────────────────────────────

--- a/crates/infr-core/src/config/manifest.rs
+++ b/crates/infr-core/src/config/manifest.rs
@@ -148,6 +148,7 @@ knobs! {
     "INFR_KV_Q8"                => "kv.force_q8",            Presence,    Ignored, "1",    migrated;
     "INFR_KV_SLOTS"             => "kv.slots",               Int,         Ignored, "8",    migrated;
     "INFR_NO_KV_RING"           => "kv.ring",                PresenceInv, Ignored, "1",    migrated;
+    "INFR_NO_DYNAMIC_KV"        => "kv.dynamic",             PresenceInv, Ignored, "1",    migrated;
     "INFR_KV_INLINE"            => "kv.inline_decode",       Presence,    Ignored, "1",    migrated;
     "INFR_KV_COOPMAT_BDA"       => "kv.coopmat_bda",         Presence,    Ignored, "1",    migrated;
     "INFR_KV_OVERFLOW"          => "kv.overflow",            Flag,        Ignored, "1",    migrated;

--- a/crates/infr-core/src/config/mod.rs
+++ b/crates/infr-core/src/config/mod.rs
@@ -139,6 +139,9 @@ cfg_struct! {
         slots: usize = 4,
         /// `INFR_NO_KV_RING` (inverted): the SWA ring cache.
         ring: bool = true,
+        /// Lazily commit supported Qwen KV caches in 32K-token increments. Backends/models without
+        /// segmented addressing retain their existing flat allocation.
+        dynamic: bool = true,
         /// `INFR_KV_INLINE`.
         inline_decode: bool = false,
         /// `INFR_KV_COOPMAT_BDA`.

--- a/crates/infr-core/src/config/mod.rs
+++ b/crates/infr-core/src/config/mod.rs
@@ -199,15 +199,13 @@ cfg_struct! {
         /// Alias eligible DRAM pager arenas through `VK_EXT_external_memory_host` so Vulkan can
         /// DMA promotions into VRAM. Unsupported devices transparently keep CPU ReBAR copies.
         host_dma: bool = true,
-        /// `INFR_LAYER_MAJOR`, TRI-state: `None` = decide from the placement (layer-major whenever
-        /// the model's weights STREAM, chunk-major when they are resident), `Some(true)` = force it
-        /// on, `Some(false)` = force it off.
+        /// `INFR_LAYER_MAJOR`, TRI-state syntax: `None` and `Some(false)` use the chunk-major
+        /// default; `Some(true)` forces layer-major where the backend and architecture support it.
         ///
         /// Layer-major prefill runs the chunk loop INSIDE the layer loop, so a prompt sweeps the
-        /// weight set once instead of once per `device.ubatch` chunk. That is the whole prefill
-        /// cost of a streamed model and nothing at all when the weights are resident, where it
-        /// would only add activation residency — hence the auto rule. Both overrides exist for A/B:
-        /// forcing it ON is how a resident model can be diffed against the chunk-major order.
+        /// weight set once instead of once per `device.ubatch` chunk. It is an explicit diagnostic
+        /// mode: `None` and `Some(false)` use chunk-major, while `Some(true)` enables layer-major
+        /// on a backend and architecture that can carry graph inputs between layer spans.
         layer_major: Option<bool> = None,
     }
 }

--- a/crates/infr-core/src/config/tests.rs
+++ b/crates/infr-core/src/config/tests.rs
@@ -80,6 +80,7 @@ fn default_config_matches_documented_defaults() {
     // §6.3 / §6.4.
     assert_eq!(d.kv.slots, 4);
     assert!(d.kv.ring);
+    assert!(d.kv.dynamic);
     assert!(!d.kv.force_q8);
     assert_eq!(d.paging.trace, None);
 
@@ -1168,6 +1169,7 @@ fn migrated_keys_are_exactly_the_landed_slices() {
         "INFR_KV_TYPE_K",
         "INFR_KV_TYPE_V",
         "INFR_MTP",
+        "INFR_NO_DYNAMIC_KV",
         "INFR_NO_GATED_RMSNORM",
         "INFR_NO_GPU_ARGMAX",
         "INFR_NO_GPU_DRAFT_PROB",

--- a/crates/infr-core/src/hostmem.rs
+++ b/crates/infr-core/src/hostmem.rs
@@ -87,8 +87,10 @@ fn windows_available_bytes(available_phys: u64, available_commit: u64) -> u64 {
 fn windows_memory_status() -> Option<windows::Win32::System::SystemInformation::MEMORYSTATUSEX> {
     use windows::Win32::System::SystemInformation::{GlobalMemoryStatusEx, MEMORYSTATUSEX};
 
-    let mut status = MEMORYSTATUSEX::default();
-    status.dwLength = std::mem::size_of::<MEMORYSTATUSEX>() as u32;
+    let mut status = MEMORYSTATUSEX {
+        dwLength: std::mem::size_of::<MEMORYSTATUSEX>() as u32,
+        ..Default::default()
+    };
     unsafe { GlobalMemoryStatusEx(&mut status).ok()? };
     Some(status)
 }
@@ -121,8 +123,10 @@ fn windows_process_resident_bytes() -> Option<u64> {
     use windows::Win32::System::ProcessStatus::{GetProcessMemoryInfo, PROCESS_MEMORY_COUNTERS};
     use windows::Win32::System::Threading::GetCurrentProcess;
 
-    let mut counters = PROCESS_MEMORY_COUNTERS::default();
-    counters.cb = std::mem::size_of::<PROCESS_MEMORY_COUNTERS>() as u32;
+    let mut counters = PROCESS_MEMORY_COUNTERS {
+        cb: std::mem::size_of::<PROCESS_MEMORY_COUNTERS>() as u32,
+        ..Default::default()
+    };
     unsafe {
         GetProcessMemoryInfo(GetCurrentProcess(), &mut counters, counters.cb).ok()?;
     }

--- a/crates/infr-core/src/hostpager.rs
+++ b/crates/infr-core/src/hostpager.rs
@@ -150,11 +150,14 @@ impl AlignedHostBuffer {
     }
 
     /// # Safety
-    /// The caller must guarantee exclusive access to this range for the duration of the returned
-    /// slice. Pager slot state and model-load sequencing provide that guarantee at current uses.
-    pub unsafe fn slice_mut(&self, offset: usize, len: usize) -> &mut [u8] {
-        debug_assert!(offset.saturating_add(len) <= self.len);
-        unsafe { std::slice::from_raw_parts_mut(self.ptr.as_ptr().add(offset), len) }
+    /// The caller must guarantee exclusive access to the destination range while the copy runs,
+    /// and `src` must not overlap it. Pager slot state and model-load sequencing provide that
+    /// guarantee at current uses.
+    pub unsafe fn copy_from_slice(&self, offset: usize, src: &[u8]) {
+        debug_assert!(offset.saturating_add(src.len()) <= self.len);
+        unsafe {
+            std::ptr::copy_nonoverlapping(src.as_ptr(), self.ptr.as_ptr().add(offset), src.len());
+        }
     }
 
     /// # Safety
@@ -279,15 +282,6 @@ impl Arena {
         debug_assert!(len <= self.slot_bytes);
         debug_assert!(self.offset(slot) + len <= self.total);
         std::slice::from_raw_parts(self.allocation.as_ptr().add(self.offset(slot)), len)
-    }
-
-    /// # Safety
-    /// The caller must have exclusively reserved `slot` in `Loading` state, and no reader may
-    /// hold a reference to it; `len <= slot_bytes`.
-    unsafe fn slot_mut(&self, slot: u32, len: usize) -> &mut [u8] {
-        debug_assert!(len <= self.slot_bytes);
-        debug_assert!(self.offset(slot) + len <= self.total);
-        std::slice::from_raw_parts_mut(self.allocation.as_ptr().add(self.offset(slot)), len)
     }
 }
 
@@ -571,7 +565,9 @@ impl InclusiveHostCache {
                 }
             };
             inner.state.insert(id, SlotState::Loading);
-            let dst = unsafe { self.arena.slot_mut(slot, len) };
+            // SAFETY: this slot was just reserved as Loading under `inner`; no reader can hold it.
+            let dst =
+                unsafe { std::slice::from_raw_parts_mut(self.arena.slot_ptr(slot, len), len) };
             if let Err(err) = self.io.read_block(&desc, dst) {
                 inner.state.remove(&id);
                 let removed = inner
@@ -675,7 +671,9 @@ impl InclusiveHostCache {
                 self.ram_evictions.fetch_add(1, Ordering::Relaxed);
             }
             inner.state.insert(requested, SlotState::Loading);
-            let dst = unsafe { self.arena.slot_mut(slot, len) };
+            // SAFETY: this slot was just reserved as Loading under `inner`; no reader can hold it.
+            let dst =
+                unsafe { std::slice::from_raw_parts_mut(self.arena.slot_ptr(slot, len), len) };
             let read_t0 = prof.then(std::time::Instant::now);
             if let Err(err) = self.io.read_block(&desc, dst) {
                 inner.state.remove(&requested);
@@ -881,7 +879,9 @@ impl InclusiveHostCache {
                     Ok(None)
                 }
                 Source::Fill { slot, desc, .. } => {
-                    let dst = unsafe { self.arena.slot_mut(*slot, job.len) };
+                    let dst = unsafe {
+                        std::slice::from_raw_parts_mut(self.arena.slot_ptr(*slot, job.len), job.len)
+                    };
                     let started = prof.then(std::time::Instant::now);
                     self.io.read_block(desc, dst)?;
                     let elapsed = started.map(|t| t.elapsed());

--- a/crates/infr-embedding/src/native.rs
+++ b/crates/infr-embedding/src/native.rs
@@ -285,11 +285,12 @@ impl NativeEmbeddingEngine {
             let mut plans = self.plans.lock().unwrap_or_else(|error| error.into_inner());
             let mut embeddings = Vec::with_capacity(encoded.len());
             for ids in encoded {
-                if !plans.contains_key(&ids.len()) {
-                    let plan = self.build_plan(ids.len())?;
-                    plans.insert(ids.len(), plan);
-                }
-                let plan = plans.get_mut(&ids.len()).expect("plan inserted above");
+                let plan = match plans.entry(ids.len()) {
+                    std::collections::hash_map::Entry::Occupied(entry) => entry.into_mut(),
+                    std::collections::hash_map::Entry::Vacant(entry) => {
+                        entry.insert(self.build_plan(ids.len())?)
+                    }
+                };
                 embeddings.push(self.execute_plan(plan, &ids, resident)?);
             }
             Ok(EmbeddingBatch {

--- a/crates/infr-hub/src/download.rs
+++ b/crates/infr-hub/src/download.rs
@@ -546,7 +546,7 @@ fn lock_file_exclusive(file: &fs::File) -> std::io::Result<()> {
     let mut overlapped = zero_overlapped();
     let ok = unsafe {
         LockFileEx(
-            file.as_raw_handle() as *mut std::ffi::c_void,
+            file.as_raw_handle(),
             LOCKFILE_EXCLUSIVE_LOCK,
             0,
             LOCK_LEN_LOW,
@@ -571,7 +571,7 @@ fn unlock_file(file: &fs::File) -> std::io::Result<()> {
     let mut overlapped = zero_overlapped();
     let ok = unsafe {
         UnlockFileEx(
-            file.as_raw_handle() as *mut std::ffi::c_void,
+            file.as_raw_handle(),
             0,
             LOCK_LEN_LOW,
             LOCK_LEN_HIGH,

--- a/crates/infr-llama/src/seam/mod.rs
+++ b/crates/infr-llama/src/seam/mod.rs
@@ -1903,6 +1903,9 @@ pub struct ModelMemoryPlan {
     pub fixed_weight_bytes: u64,
     pub persistent_state_bytes: u64,
     pub runtime_reserve_bytes: u64,
+    /// Maximum lazily committed per-token state. It shares the unified arena with experts and
+    /// runtime scratch, but remains separately named so diagnostics never call KV "runtime".
+    pub dynamic_state_reserve_bytes: u64,
     pub weight_packing_margin_bytes: u64,
     pub load_driver_reserve_bytes: u64,
     pub post_load_reserve_bytes: u64,
@@ -1952,18 +1955,43 @@ impl ModelMemoryPlan {
         load_driver_reserve_bytes: u64,
         post_load_reserve_bytes: u64,
     ) -> Option<Self> {
+        Self::new_with_dynamic_reserve(
+            total_room_bytes,
+            fixed_weight_bytes,
+            persistent_state_bytes,
+            runtime_reserve_bytes,
+            0,
+            weight_packing_margin_bytes,
+            load_driver_reserve_bytes,
+            post_load_reserve_bytes,
+        )
+    }
+
+    #[allow(clippy::too_many_arguments)]
+    pub fn new_with_dynamic_reserve(
+        total_room_bytes: u64,
+        fixed_weight_bytes: u64,
+        persistent_state_bytes: u64,
+        runtime_reserve_bytes: u64,
+        dynamic_state_reserve_bytes: u64,
+        weight_packing_margin_bytes: u64,
+        load_driver_reserve_bytes: u64,
+        post_load_reserve_bytes: u64,
+    ) -> Option<Self> {
         let persistent = fixed_weight_bytes.saturating_add(persistent_state_bytes);
         (persistent <= total_room_bytes).then(|| Self {
             total_room_bytes,
             fixed_weight_bytes,
             persistent_state_bytes,
             runtime_reserve_bytes,
+            dynamic_state_reserve_bytes,
             weight_packing_margin_bytes,
             load_driver_reserve_bytes,
             post_load_reserve_bytes,
             expert_cache_bytes: total_room_bytes
                 .saturating_sub(persistent)
                 .saturating_sub(runtime_reserve_bytes)
+                .saturating_sub(dynamic_state_reserve_bytes)
                 .saturating_sub(weight_packing_margin_bytes)
                 .saturating_sub(load_driver_reserve_bytes)
                 .saturating_sub(post_load_reserve_bytes),
@@ -1974,6 +2002,7 @@ impl ModelMemoryPlan {
         self.fixed_weight_bytes
             .saturating_add(self.persistent_state_bytes)
             .saturating_add(self.runtime_reserve_bytes)
+            .saturating_add(self.dynamic_state_reserve_bytes)
             .saturating_add(self.weight_packing_margin_bytes)
             .saturating_add(self.load_driver_reserve_bytes)
             .saturating_add(self.post_load_reserve_bytes)
@@ -1983,7 +2012,12 @@ impl ModelMemoryPlan {
     /// the target Expert occupancy, then added back here because it borrows the same bytes only
     /// while a graph is active instead of living in a separate permanently idle reservation.
     pub fn elastic_pool_bytes(self, expert_cache_target_bytes: u64) -> u64 {
-        expert_cache_target_bytes.saturating_add(self.runtime_reserve_bytes)
+        expert_cache_target_bytes.saturating_add(self.elastic_reserve_bytes())
+    }
+
+    pub fn elastic_reserve_bytes(self) -> u64 {
+        self.runtime_reserve_bytes
+            .saturating_add(self.dynamic_state_reserve_bytes)
     }
 }
 
@@ -2695,6 +2729,20 @@ pub(crate) fn vulkan_moe_binder<'a>(
         let ring = kv_ring_wanted(cfg, ec);
         let k_fmt = vulkan_kv_fmt_for_budget(cfg, ec, ec.kv.type_k);
         let v_fmt = vulkan_kv_fmt_for_budget(cfg, ec, ec.kv.type_v);
+        let dynamic_layout = (ec.kv.dynamic
+            && cfg.qwen35
+            && !ring
+            && !ec.kv.overflow
+            && matches!(k_fmt, DType::F16 | DType::Q8_0)
+            && matches!(v_fmt, DType::F16 | DType::Q8_0))
+        .then(|| {
+            segmented_kv::SegmentedKvLayout::for_qwen(cfg, want_ctx, k_fmt, v_fmt)
+                .expect("qwen35 has segmented KV geometry")
+        });
+        let dynamic_kv_reserve = dynamic_layout
+            .as_ref()
+            .map(|layout| layout.committed_bytes(want_ctx))
+            .unwrap_or(0);
         let kv_bytes_at = |ubatch| match (k_fmt, v_fmt) {
             (DType::Q8_0, DType::Q8_0) => kv_bytes_estimate(cfg, want_ctx, ring, ubatch, true),
             (DType::F16, DType::F16) => kv_bytes_estimate(cfg, want_ctx, ring, ubatch, false),
@@ -2703,6 +2751,7 @@ pub(crate) fn vulkan_moe_binder<'a>(
         let initial_ubatch = ubatch_rows(ec);
         let mut selected_ubatch = initial_ubatch;
         let kv_bytes = kv_bytes_at(selected_ubatch);
+        let persistent_state = kv_bytes.saturating_sub(dynamic_kv_reserve);
         // Reserve the workspace for the chunk this session will actually execute. A user selecting
         // 4096 rows still gets the full 4K reserve; the default 1024-row session no longer strands
         // the difference behind a permanent 2 GiB/4K assumption. Prefill's layer ring already
@@ -2710,11 +2759,12 @@ pub(crate) fn vulkan_moe_binder<'a>(
         let runtime_reserve = dense_act_reserve_at(cfg, &caps, want_ctx, selected_ubatch);
         let packing_margin = resident_weight_packing_margin(fp.dense);
         let load_driver_reserve = session_load_driver_reserve(cfg, ec);
-        let Some(mut plan) = ModelMemoryPlan::new_with_reserves(
+        let Some(mut plan) = ModelMemoryPlan::new_with_dynamic_reserve(
             room,
             fp.dense,
-            kv_bytes,
+            persistent_state,
             runtime_reserve,
+            dynamic_kv_reserve,
             packing_margin,
             load_driver_reserve,
             POST_KV_DEVICE_RESERVE,
@@ -2740,12 +2790,14 @@ pub(crate) fn vulkan_moe_binder<'a>(
         if paged_target.is_some_and(|bytes| bytes < prefill_floor) {
             for candidate in moe_ubatch_fallback_candidates(ec).into_iter().skip(1) {
                 let candidate_kv = kv_bytes_at(candidate);
+                let candidate_persistent = candidate_kv.saturating_sub(dynamic_kv_reserve);
                 let candidate_runtime = dense_act_reserve_at(cfg, &caps, want_ctx, candidate);
-                let Some(candidate_plan) = ModelMemoryPlan::new_with_reserves(
+                let Some(candidate_plan) = ModelMemoryPlan::new_with_dynamic_reserve(
                     room,
                     fp.dense,
-                    candidate_kv,
+                    candidate_persistent,
                     candidate_runtime,
+                    dynamic_kv_reserve,
                     packing_margin,
                     load_driver_reserve,
                     POST_KV_DEVICE_RESERVE,
@@ -2819,17 +2871,21 @@ pub(crate) fn vulkan_moe_binder<'a>(
         }
         let cache_layout = if cfg.deepseek4 {
             "fp8-kv+mxfp4-index".to_string()
+        } else if dynamic_kv_reserve > 0 {
+            format!("dynamic-32k k={k_fmt:?}, v={v_fmt:?}")
         } else {
             format!("k={k_fmt:?}, v={v_fmt:?}")
         };
         tracing::info!(
             "VRAM plan: total_room={:.2} GB fixed={:.2} GB state={:.2} GB runtime_elastic={:.2} GB \
+             dynamic_state_elastic={:.2} GB \
              packing_margin={:.2} GB load_driver={:.2} GB post_load={:.2} GB \
              expert_cache_target={:.2} GB elastic_pool={:.2} GB ({cache_layout}, ctx={want_ctx})",
             room as f64 / 1e9,
             plan.fixed_weight_bytes as f64 / 1e9,
             plan.persistent_state_bytes as f64 / 1e9,
             plan.runtime_reserve_bytes as f64 / 1e9,
+            plan.dynamic_state_reserve_bytes as f64 / 1e9,
             plan.weight_packing_margin_bytes as f64 / 1e9,
             plan.load_driver_reserve_bytes as f64 / 1e9,
             plan.post_load_reserve_bytes as f64 / 1e9,
@@ -3002,10 +3058,11 @@ pub(crate) fn vulkan_moe_binder<'a>(
             let plan = pager_memory_plan.expect("n_paged > 0 carries its selected memory plan");
             let prefill_floor = pager_prefill_floor_bytes;
             let planned_pager_budget = pager_budget_bytes;
-            let minimum_pager_budget = plan.runtime_reserve_bytes.saturating_add(prefill_floor);
+            let elastic_reserve = plan.elastic_reserve_bytes();
+            let minimum_pager_budget = elastic_reserve.saturating_add(prefill_floor);
             let required_after_arena = plan
                 .minimum_required_bytes()
-                .saturating_sub(plan.runtime_reserve_bytes);
+                .saturating_sub(elastic_reserve);
             let adaptive_arena = cache_override.is_none();
             let mut candidate_budget = pager_budget_bytes;
             let mut attempts = 0usize;
@@ -3024,12 +3081,12 @@ pub(crate) fn vulkan_moe_binder<'a>(
                     ));
                 };
                 let physical_bytes = moe_pool_capacity_bytes(&logical_pools, &candidate_slots);
-                if physical_bytes.saturating_sub(plan.runtime_reserve_bytes) < prefill_floor {
+                if physical_bytes.saturating_sub(elastic_reserve) < prefill_floor {
                     return Err(anyhow!(
                         "MoE mapped arena cannot retain one complete Prefill layer after its \
                          runtime reserve (arena {:.2} MiB, runtime {:.2} MiB, layer {:.2} MiB)",
                         physical_bytes as f64 / 2f64.powi(20),
-                        plan.runtime_reserve_bytes as f64 / 2f64.powi(20),
+                        elastic_reserve as f64 / 2f64.powi(20),
                         prefill_floor as f64 / 2f64.powi(20),
                     ));
                 }
@@ -3046,7 +3103,7 @@ pub(crate) fn vulkan_moe_binder<'a>(
                         if live_room >= required_after_arena {
                             pager_budget_bytes = physical_bytes;
                             expert_cache_target_bytes = expert_cache_target_bytes
-                                .min(physical_bytes.saturating_sub(plan.runtime_reserve_bytes));
+                                .min(physical_bytes.saturating_sub(elastic_reserve));
                             if attempts > 1 {
                                 tracing::warn!(
                                     planned_bytes = planned_pager_budget,
@@ -6403,6 +6460,36 @@ mod seam_helper_tests {
         assert_eq!(
             super::session_load_driver_reserve(&cfg, &explicit),
             if cfg!(windows) { 2 * GIB } else { 0 }
+        );
+    }
+
+    #[test]
+    fn dynamic_kv_reserve_borrows_the_expert_arena_without_double_counting() {
+        const GIB: u64 = 1024 * 1024 * 1024;
+        let plan = super::ModelMemoryPlan::new_with_dynamic_reserve(
+            24 * GIB,
+            5 * GIB,
+            1 * GIB,
+            2 * GIB,
+            4 * GIB,
+            1 * GIB,
+            0,
+            1 * GIB,
+        )
+        .expect("dynamic KV plan");
+
+        assert_eq!(plan.expert_cache_bytes, 10 * GIB);
+        assert_eq!(plan.minimum_required_bytes(), 14 * GIB);
+        assert_eq!(plan.elastic_reserve_bytes(), 6 * GIB);
+        assert_eq!(plan.elastic_pool_bytes(plan.expert_cache_bytes), 16 * GIB);
+        assert_eq!(
+            plan.fixed_weight_bytes
+                + plan.persistent_state_bytes
+                + plan.weight_packing_margin_bytes
+                + plan.post_load_reserve_bytes
+                + plan.elastic_pool_bytes(plan.expert_cache_bytes),
+            plan.total_room_bytes,
+            "runtime and maximum KV return to the shared arena exactly once"
         );
     }
 

--- a/crates/infr-llama/src/seam/mod.rs
+++ b/crates/infr-llama/src/seam/mod.rs
@@ -2730,14 +2730,14 @@ pub(crate) fn vulkan_moe_binder<'a>(
         let k_fmt = vulkan_kv_fmt_for_budget(cfg, ec, ec.kv.type_k);
         let v_fmt = vulkan_kv_fmt_for_budget(cfg, ec, ec.kv.type_v);
         let dynamic_layout = (ec.kv.dynamic
-            && cfg.qwen35
+            && (cfg.qwen35 || cfg.qwen4exp)
             && !ring
             && !ec.kv.overflow
             && matches!(k_fmt, DType::F16 | DType::Q8_0)
             && matches!(v_fmt, DType::F16 | DType::Q8_0))
         .then(|| {
             segmented_kv::SegmentedKvLayout::for_qwen(cfg, want_ctx, k_fmt, v_fmt)
-                .expect("qwen35 has segmented KV geometry")
+                .expect("Qwen hybrid models have segmented KV geometry")
         });
         let dynamic_kv_reserve = dynamic_layout
             .as_ref()

--- a/crates/infr-llama/src/seam/mod.rs
+++ b/crates/infr-llama/src/seam/mod.rs
@@ -21,6 +21,7 @@ pub mod model;
 mod ple;
 mod runner;
 mod sc;
+mod segmented_kv;
 mod weights;
 
 pub(crate) use runner::generate_dense_backend;

--- a/crates/infr-llama/src/seam/mod.rs
+++ b/crates/infr-llama/src/seam/mod.rs
@@ -841,6 +841,61 @@ pub(crate) fn dense_act_reserve_at(
     })
 }
 
+/// F16 expansion buffers held by Vulkan while a batched attention op reads a Q8_0 KV cache.
+///
+/// The adapter pools these as `(tag, bytes)` under separate `kvdeq_k` and `kvdeq_v` tags. A model
+/// with one attention geometry therefore keeps one buffer per Q8 side; mixed layer geometries keep
+/// one per distinct byte size. Mirror that exact lifetime here instead of charging once per layer.
+fn q8_prefill_scratch_bytes(
+    cfg: &Config,
+    want_ctx: usize,
+    ring: bool,
+    ubatch: usize,
+    k_fmt: DType,
+    v_fmt: DType,
+) -> u64 {
+    if ubatch.min(want_ctx) <= 1 {
+        return 0;
+    }
+
+    let mut k_sizes = std::collections::BTreeSet::new();
+    let mut v_sizes = std::collections::BTreeSet::new();
+    for l in 0..cfg.n_layer {
+        if cfg.is_mla_layer(l) || cfg.is_recurrent_layer(l) {
+            continue;
+        }
+        let rows = kv_rows_at(cfg, l, want_ctx, ring, ubatch) as u64;
+        let (k_row, v_row) = kv_row_elems(cfg, l);
+        if k_fmt == DType::Q8_0 {
+            k_sizes.insert(rows.saturating_mul(k_row as u64).saturating_mul(2));
+        }
+        if v_fmt == DType::Q8_0 {
+            v_sizes.insert(rows.saturating_mul(v_row as u64).saturating_mul(2));
+        }
+    }
+
+    k_sizes
+        .into_iter()
+        .chain(v_sizes)
+        .fold(0u64, u64::saturating_add)
+}
+
+/// Runtime workspace priced by placement and checked against Vulkan's measured activation peak.
+/// This includes the graph's ordinary activation pools plus format-specific KV read scratch.
+pub(crate) fn runtime_reserve_at(
+    cfg: &Config,
+    caps: &Capabilities,
+    want_ctx: usize,
+    ring: bool,
+    ubatch: usize,
+    k_fmt: DType,
+    v_fmt: DType,
+) -> u64 {
+    dense_act_reserve_at(cfg, caps, want_ctx, ubatch).saturating_add(q8_prefill_scratch_bytes(
+        cfg, want_ctx, ring, ubatch, k_fmt, v_fmt,
+    ))
+}
+
 /// Number of ubatches in one Qwen3.8 layer-major prefill group. Eight leaves enough same-layer
 /// work to amortize/pipeline expert staging without retaining a long prompt's four residual
 /// streams all at once.
@@ -1230,6 +1285,13 @@ pub(crate) fn kv_unset(ec: &EngineConfig) -> bool {
     !ec.kv.type_k_specified && !ec.kv.type_v_specified && !ec.kv.force_q8
 }
 
+/// The automatic Vulkan KV format when the user did not choose one explicitly. Keep this out of
+/// [`EngineConfig`]'s generic defaults: CPU/Metal sessions retain their backend-specific behavior,
+/// while every Vulkan placement estimate and allocation can ask the same model-layout gate.
+pub(crate) fn kv_default_q8(cfg: &Config, ec: &EngineConfig) -> bool {
+    kv_unset(ec) && kv_q8_layout_ok(cfg)
+}
+
 /// Per-token (K, V) ELEMENT counts for layer `l` — the one answer to "how wide is a row of this
 /// layer's KV cache", shared by the runner's allocation, the graph declaration, the fork/seed
 /// copies and every footprint estimate. Multiply by a row count for a whole cache side.
@@ -1368,7 +1430,9 @@ fn vulkan_kv_fmt_for_budget(cfg: &Config, ec: &EngineConfig, requested: Option<D
         return match requested {
             Some(DType::Q8_0) if block_aligned => DType::Q8_0,
             Some(DType::F16) => DType::F16,
-            _ if (ec.kv.force_q8 || kv_auto_q8()) && block_aligned => DType::Q8_0,
+            _ if (ec.kv.force_q8 || kv_auto_q8() || kv_default_q8(cfg, ec)) && block_aligned => {
+                DType::Q8_0
+            }
             _ => DType::F16,
         };
     }
@@ -1382,7 +1446,9 @@ fn vulkan_kv_fmt_for_budget(cfg: &Config, ec: &EngineConfig, requested: Option<D
             dt
         }
         Some(dt @ (DType::F16 | DType::Bf16 | DType::F32)) => dt,
-        _ if (ec.kv.force_q8 || kv_auto_q8()) && block_aligned => DType::Q8_0,
+        _ if (ec.kv.force_q8 || kv_auto_q8() || kv_default_q8(cfg, ec)) && block_aligned => {
+            DType::Q8_0
+        }
         _ => DType::F16,
     }
 }
@@ -1727,8 +1793,9 @@ pub fn estimate_kv_bytes(
 ///     never learned the ring split — they keep full-context caches, documented scope gate);
 ///   - `kv.ring = false` (`INFR_NO_KV_RING=1`, A/B and escape hatch).
 pub(crate) fn kv_ring_wanted(cfg: &Config, ec: &EngineConfig) -> bool {
-    // Not-supplied = the f16 default = ring-capable; otherwise the requested format must PARSE to
-    // f16 or q8 (a name the runner would not recognize either is not ring-capable — the
+    // Not supplied is ring-capable under either automatic Vulkan Q8 or another backend's F16
+    // default; otherwise the requested format must PARSE to f16 or q8 (a name the runner would
+    // not recognize either is not ring-capable — the
     // `specified && dtype.is_none()` case, §11 decision 8). The dtype comes from the ONE shared
     // spelling table (`budget::parse_kv_dtype`, now applied in the config's env layer), so adding
     // an alias cannot make this gate and the runner disagree.
@@ -1782,6 +1849,24 @@ pub(crate) fn placement_ring(cfg: &Config, ec: &EngineConfig, k_fmt: DType, v_fm
         && matches!(v_fmt, DType::F16 | DType::Q8_0)
 }
 
+/// Whether this session requests the segmented Qwen KV layout. The implementation currently
+/// relies on Q8_0's compact fixed-size segments; explicit F16 or a mixed pair keeps the established
+/// flat allocation path until segmented F16 has its own performance and allocation contract.
+pub(crate) fn segmented_kv_wanted(
+    cfg: &Config,
+    ec: &EngineConfig,
+    ring: bool,
+    k_fmt: DType,
+    v_fmt: DType,
+) -> bool {
+    ec.kv.dynamic
+        && (cfg.qwen35 || cfg.qwen4exp)
+        && !ring
+        && !ec.kv.overflow
+        && k_fmt == DType::Q8_0
+        && v_fmt == DType::Q8_0
+}
+
 /// Bytes a FULLY-RESIDENT dense session needs at one EXPLICIT prefill chunk height and KV format
 /// pair: weights + the exact KV allocation ([`kv_bytes_estimate_fmt`]) + the activation reserve
 /// ([`dense_act_reserve_at`]). The arithmetic both the fit math and the placement sweep compare
@@ -1800,7 +1885,9 @@ pub(crate) fn dense_resident_need(
         .saturating_add(kv_bytes_estimate_fmt(
             cfg, want_ctx, ring, ubatch, k_fmt, v_fmt,
         ))
-        .saturating_add(dense_act_reserve_at(cfg, caps, want_ctx, ubatch))
+        .saturating_add(runtime_reserve_at(
+            cfg, caps, want_ctx, ring, ubatch, k_fmt, v_fmt,
+        ))
 }
 
 /// Does a fully-resident dense session at this chunk height fit the ALLOCATOR's ceiling?
@@ -2100,9 +2187,23 @@ fn session_load_driver_reserve(cfg: &Config, ec: &EngineConfig) -> u64 {
 }
 
 /// Conservative load-time runtime reserve for control planes that do not own a live backend yet.
-/// Placement calls the same activation formula with the selected device's real capabilities.
+/// Placement calls the same formula with the selected device's real capabilities. These helpers
+/// describe the automatic Vulkan format: Q8_0 on a compatible layout, otherwise F16.
 pub fn estimate_runtime_reserve_bytes(cfg: &Config, want_ctx: usize, ubatch: usize) -> u64 {
-    dense_act_reserve_at(cfg, &Capabilities::default(), want_ctx, ubatch)
+    let fmt = if kv_q8_layout_ok(cfg) {
+        DType::Q8_0
+    } else {
+        DType::F16
+    };
+    runtime_reserve_at(
+        cfg,
+        &Capabilities::default(),
+        want_ctx,
+        false,
+        ubatch,
+        fmt,
+        fmt,
+    )
 }
 
 /// Device-aware form of [`estimate_runtime_reserve_bytes`] for control planes that have probed
@@ -2119,7 +2220,12 @@ pub fn estimate_runtime_reserve_bytes_for_device(
         caps.coopmat_f16 = Some(infr_core::COOPMAT_TILE_16);
         caps.max_shared_memory_bytes = infr_vulkan::FLASH_HD256_BM16_SHARED;
     }
-    dense_act_reserve_at(cfg, &caps, want_ctx, ubatch)
+    let fmt = if kv_q8_layout_ok(cfg) {
+        DType::Q8_0
+    } else {
+        DType::F16
+    };
+    runtime_reserve_at(cfg, &caps, want_ctx, false, ubatch, fmt, fmt)
 }
 
 fn moe_expert_layer(name: &str) -> Option<usize> {
@@ -2408,7 +2514,7 @@ fn kv_fit_ctx_in_budgets(
     let fits = |ctx: usize| -> bool {
         cands.iter().any(|&ubatch| {
             let kv = kv_bytes_estimate_fmt(cfg, ctx, ring, ubatch, k_fmt, v_fmt);
-            let reserve = dense_act_reserve_at(cfg, caps, ctx, ubatch);
+            let reserve = runtime_reserve_at(cfg, caps, ctx, ring, ubatch, k_fmt, v_fmt);
             elastic_activation_budget.map_or_else(
                 || kv.saturating_add(reserve.max(minimum_elastic_bytes)) <= persistent_budget,
                 |activation_budget| {
@@ -2565,7 +2671,9 @@ pub(crate) fn reclamp_ctx_to_live_room(
          memory; set INFR_CTX to override",
         gib(room),
         gib(kv_bytes_estimate_fmt(cfg, fit, ring, ubatch, k_fmt, v_fmt)),
-        gib(dense_act_reserve_at(cfg, &caps, fit, ubatch)),
+        gib(runtime_reserve_at(
+            cfg, &caps, fit, ring, ubatch, k_fmt, v_fmt,
+        )),
         gib(POST_KV_DEVICE_RESERVE),
     );
     fit
@@ -2722,13 +2830,7 @@ pub(crate) fn vulkan_moe_binder<'a>(
         let ring = kv_ring_wanted(cfg, ec);
         let k_fmt = vulkan_kv_fmt_for_budget(cfg, ec, ec.kv.type_k);
         let v_fmt = vulkan_kv_fmt_for_budget(cfg, ec, ec.kv.type_v);
-        let dynamic_layout = (ec.kv.dynamic
-            && (cfg.qwen35 || cfg.qwen4exp)
-            && !ring
-            && !ec.kv.overflow
-            && matches!(k_fmt, DType::F16 | DType::Q8_0)
-            && matches!(v_fmt, DType::F16 | DType::Q8_0))
-        .then(|| {
+        let dynamic_layout = segmented_kv_wanted(cfg, ec, ring, k_fmt, v_fmt).then(|| {
             segmented_kv::SegmentedKvLayout::for_qwen(cfg, want_ctx, k_fmt, v_fmt)
                 .expect("Qwen hybrid models have segmented KV geometry")
         });
@@ -2749,7 +2851,8 @@ pub(crate) fn vulkan_moe_binder<'a>(
         // 4096 rows still gets the full 4K reserve; the default 1024-row session no longer strands
         // the difference behind a permanent 2 GiB/4K assumption. Prefill's layer ring already
         // borrows only cold Decode arena ranges and returns them on `enter_decode`.
-        let runtime_reserve = dense_act_reserve_at(cfg, &caps, want_ctx, selected_ubatch);
+        let runtime_reserve =
+            runtime_reserve_at(cfg, &caps, want_ctx, ring, selected_ubatch, k_fmt, v_fmt);
         let packing_margin = resident_weight_packing_margin(fp.dense);
         let load_driver_reserve = session_load_driver_reserve(cfg, ec);
         let Some(mut plan) = ModelMemoryPlan::new_with_dynamic_reserve(
@@ -2784,7 +2887,8 @@ pub(crate) fn vulkan_moe_binder<'a>(
             for candidate in moe_ubatch_fallback_candidates(ec).into_iter().skip(1) {
                 let candidate_kv = kv_bytes_at(candidate);
                 let candidate_persistent = candidate_kv.saturating_sub(dynamic_kv_reserve);
-                let candidate_runtime = dense_act_reserve_at(cfg, &caps, want_ctx, candidate);
+                let candidate_runtime =
+                    runtime_reserve_at(cfg, &caps, want_ctx, ring, candidate, k_fmt, v_fmt);
                 let Some(candidate_plan) = ModelMemoryPlan::new_with_dynamic_reserve(
                     room,
                     fp.dense,
@@ -3406,14 +3510,11 @@ pub(crate) fn vulkan_moe_binder<'a>(
         // KV small enough to take the try-resident tier at real contexts instead of streaming.
         let configured_k = vulkan_kv_fmt_for_budget(cfg, ec, ec.kv.type_k);
         let configured_v = vulkan_kv_fmt_for_budget(cfg, ec, ec.kv.type_v);
-        let has_explicit_kv = ec.kv.type_k.is_some() || ec.kv.type_v.is_some() || ec.kv.force_q8;
         let kv_fmts = |try_auto_q8: bool| {
             if try_auto_q8 {
                 (DType::Q8_0, DType::Q8_0)
-            } else if has_explicit_kv {
-                (configured_k, configured_v)
             } else {
-                (DType::F16, DType::F16)
+                (configured_k, configured_v)
             }
         };
         // Does weights + KV + the honest activation reserve fit at this (chunk, fmt)? Through the
@@ -3485,6 +3586,7 @@ pub(crate) fn vulkan_moe_binder<'a>(
         if !resident
             && cache_override.is_none()
             && !kv_auto_q8()
+            && !kv_default_q8(cfg, ec)
             && kv_unset(ec)
             && kv_q8_layout_ok(cfg)
         {
@@ -5268,6 +5370,125 @@ mod seam_helper_tests {
     }
 
     #[test]
+    fn vulkan_default_kv_is_q8_only_when_unset_and_compatible() {
+        let cfg = qwen3_14b();
+        let unset = EngineConfig::default();
+        assert!(super::kv_default_q8(&cfg, &unset));
+        assert_eq!(
+            super::vulkan_kv_fmt_for_budget(&cfg, &unset, None),
+            DType::Q8_0
+        );
+
+        let explicit_f16 = EngineConfig {
+            kv: infr_core::config::KvCfg {
+                type_k: Some(DType::F16),
+                type_k_specified: true,
+                type_v: Some(DType::F16),
+                type_v_specified: true,
+                ..Default::default()
+            },
+            ..Default::default()
+        };
+        assert!(!super::kv_default_q8(&cfg, &explicit_f16));
+        assert_eq!(
+            super::vulkan_kv_fmt_for_budget(&cfg, &explicit_f16, Some(DType::F16)),
+            DType::F16
+        );
+
+        let mla = deepseek_v2_lite_kv();
+        assert!(!super::kv_default_q8(&mla, &unset));
+        assert_eq!(
+            super::vulkan_kv_fmt_for_budget(&mla, &unset, None),
+            DType::F16
+        );
+    }
+
+    #[test]
+    fn segmented_kv_requires_q8_on_both_sides() {
+        let cfg = Config {
+            qwen35: true,
+            n_layer: 1,
+            n_kv: 2,
+            head_dim: 128,
+            full_attn_interval: 1,
+            ..Default::default()
+        };
+        let mut ec = EngineConfig::default();
+        ec.kv.dynamic = true;
+        assert!(super::segmented_kv_wanted(
+            &cfg,
+            &ec,
+            false,
+            DType::Q8_0,
+            DType::Q8_0
+        ));
+        assert!(!super::segmented_kv_wanted(
+            &cfg,
+            &ec,
+            false,
+            DType::F16,
+            DType::F16
+        ));
+        assert!(!super::segmented_kv_wanted(
+            &cfg,
+            &ec,
+            false,
+            DType::Q8_0,
+            DType::F16
+        ));
+
+        ec.kv.dynamic = false;
+        assert!(!super::segmented_kv_wanted(
+            &cfg,
+            &ec,
+            false,
+            DType::Q8_0,
+            DType::Q8_0
+        ));
+        ec.kv.dynamic = true;
+        ec.kv.overflow = true;
+        assert!(!super::segmented_kv_wanted(
+            &cfg,
+            &ec,
+            false,
+            DType::Q8_0,
+            DType::Q8_0
+        ));
+        ec.kv.overflow = false;
+        assert!(!super::segmented_kv_wanted(
+            &cfg,
+            &ec,
+            true,
+            DType::Q8_0,
+            DType::Q8_0
+        ));
+    }
+
+    #[test]
+    fn q8_runtime_reserve_includes_pooled_f16_kv_expansion() {
+        let cfg = qwen3_14b();
+        let (ctx, ubatch) = (250_000usize, 1024usize);
+        let caps = conservative_caps();
+        let f16 =
+            super::runtime_reserve_at(&cfg, &caps, ctx, false, ubatch, DType::F16, DType::F16);
+        let q8 =
+            super::runtime_reserve_at(&cfg, &caps, ctx, false, ubatch, DType::Q8_0, DType::Q8_0);
+        let one_side = ctx as u64 * (cfg.n_kv * cfg.head_dim) as u64 * 2;
+        assert_eq!(q8 - f16, 2 * one_side);
+        assert!(
+            super::runtime_reserve_at(
+                &cfg,
+                &caps,
+                ctx / 2,
+                false,
+                ubatch,
+                DType::Q8_0,
+                DType::Q8_0,
+            ) < q8
+        );
+    }
+
+    #[test]
     fn kv_side_bytes_prices_each_side_in_its_own_dtype() {
         // q8 prices K+V at ~half the f16 bytes (34 B / 32-elem block vs 2 B/elem, ×2 sides).
         let elems = 32_000usize;
@@ -5871,7 +6092,7 @@ mod seam_helper_tests {
         let need = |ctx: usize, ub: usize| {
             weights
                 + super::kv_bytes_estimate_fmt(cfg, ctx, ring, ub, k, v)
-                + super::dense_act_reserve_at(cfg, &conservative_caps(), ctx, ub)
+                + super::runtime_reserve_at(cfg, &conservative_caps(), ctx, ring, ub, k, v)
         };
         let cands = super::ubatch_candidates(ec);
         let best = |ctx: usize| cands.iter().map(|&ub| need(ctx, ub)).min().expect("ladder");
@@ -6148,13 +6369,31 @@ mod seam_helper_tests {
         let (ctx, ubatch) = (200_000usize, 1024usize);
         let conservative = super::dense_act_reserve_at(&cfg, &conservative_caps(), ctx, ubatch);
         let flash = super::dense_act_reserve_at(&cfg, &hd256_flash_caps(), ctx, ubatch);
+        let automatic_conservative = super::runtime_reserve_at(
+            &cfg,
+            &conservative_caps(),
+            ctx,
+            false,
+            ubatch,
+            DType::Q8_0,
+            DType::Q8_0,
+        );
+        let automatic_flash = super::runtime_reserve_at(
+            &cfg,
+            &hd256_flash_caps(),
+            ctx,
+            false,
+            ubatch,
+            DType::Q8_0,
+            DType::Q8_0,
+        );
         assert_eq!(
             super::estimate_runtime_reserve_bytes_for_device(&cfg, ctx, ubatch, false),
-            conservative,
+            automatic_conservative,
         );
         assert_eq!(
             super::estimate_runtime_reserve_bytes_for_device(&cfg, ctx, ubatch, true),
-            flash,
+            automatic_flash,
         );
         let rows = ubatch as u64;
         let score_per_row = (2 * cfg.n_head * ctx.next_multiple_of(256)) as u64;
@@ -6395,7 +6634,7 @@ mod seam_helper_tests {
             20 * GIB,
             4 * GIB,
             2 * GIB,
-            1 * GIB,
+            GIB,
             512 * MIB,
             0,
             256 * MIB,
@@ -6423,7 +6662,7 @@ mod seam_helper_tests {
             20 * GIB,
             4 * GIB,
             2 * GIB,
-            1 * GIB,
+            GIB,
             512 * MIB,
             1536 * MIB,
             256 * MIB,
@@ -6434,16 +6673,14 @@ mod seam_helper_tests {
 
         let mut cfg = Config::default();
         assert_eq!(super::load_driver_reserve(&cfg), 0);
-        let estimated =
-            super::estimate_model_memory_plan(&cfg, 4 * GIB, 20 * GIB, 2 * GIB, 1 * GIB)
-                .expect("control-plane estimate");
+        let estimated = super::estimate_model_memory_plan(&cfg, 4 * GIB, 20 * GIB, 2 * GIB, GIB)
+            .expect("control-plane estimate");
         assert_eq!(estimated.weight_packing_margin_bytes, 256 * MIB);
         assert_eq!(estimated.post_load_reserve_bytes, 256 * MIB);
         cfg.deepseek4 = true;
         assert_eq!(super::load_driver_reserve(&cfg), 1536 * MIB);
-        let estimated =
-            super::estimate_model_memory_plan(&cfg, 4 * GIB, 20 * GIB, 2 * GIB, 1 * GIB)
-                .expect("DeepSeek control-plane estimate");
+        let estimated = super::estimate_model_memory_plan(&cfg, 4 * GIB, 20 * GIB, 2 * GIB, GIB)
+            .expect("DeepSeek control-plane estimate");
         assert_eq!(estimated.load_driver_reserve_bytes, 1536 * MIB);
 
         cfg.deepseek4 = false;
@@ -6495,12 +6732,12 @@ mod seam_helper_tests {
         let plan = super::ModelMemoryPlan::new_with_dynamic_reserve(
             24 * GIB,
             5 * GIB,
-            1 * GIB,
+            GIB,
             2 * GIB,
             4 * GIB,
-            1 * GIB,
+            GIB,
             0,
-            1 * GIB,
+            GIB,
         )
         .expect("dynamic KV plan");
 

--- a/crates/infr-llama/src/seam/mod.rs
+++ b/crates/infr-llama/src/seam/mod.rs
@@ -883,25 +883,21 @@ pub(crate) fn layer_major_act_bytes(cfg: &Config, want_ctx: usize, ubatch: usize
 /// L+1 — instead of running the whole model per chunk?
 ///
 /// The two orders compute the same thing; they differ in what they re-read. Chunk-major sweeps the
-/// entire weight set once PER CHUNK, which is free when the weights are resident and is the whole
-/// prefill cost when they stream: measured on Qwen3-14B Q8_0 at ctx 4096, the 1024-row default read
-/// 25.26 GB against a single sweep's 6.32 GB, and prefilled 3.08x slower for it. Layer-major reads
-/// one sweep regardless of chunk count, at the cost of holding residual streams across layer
-/// boundaries ([`layer_major_act_bytes`]). Qwen3.8 bounds that lifetime to fixed groups; ordinary
-/// streaming models retain the whole prompt. The trade pays when there is I/O to save, hence the
-/// default of "on exactly when the weights stream".
+/// entire weight set once PER CHUNK. Layer-major can reduce those reads, at the cost of retaining
+/// residual streams and introducing one execute boundary per layer/chunk pair
+/// ([`layer_major_act_bytes`]). That trade helped one streamed dense model, but regressed paged
+/// Qwen3.8 prefill by more than an order of magnitude, so chunk-major is the default everywhere.
 ///
-/// `paging.layer_major` overrides in both directions (A/B, and the only way to put a RESIDENT model
-/// on this path). Either way it needs a backend that carries a bound `Input` from one execute to the
-/// next, which is what threads the residual stream between two layers' dispatches, and an
-/// architecture whose layer stack can be entered past layer 0 at all (`spannable`).
+/// `paging.layer_major = true` is the only way onto this diagnostic path. It needs a backend that
+/// carries a bound `Input` from one execute to the next, which is what threads the residual stream
+/// between two layers' dispatches, and an architecture whose layer stack can be entered past layer
+/// 0 at all (`spannable`).
 pub(crate) fn layer_major_prefill(
     ec: &EngineConfig,
     caps: &infr_core::backend::Capabilities,
-    streaming: bool,
     spannable: bool,
 ) -> bool {
-    let want = ec.paging.layer_major.unwrap_or(streaming);
+    let want = ec.paging.layer_major == Some(true);
     if want && !spannable {
         // gemma4-E2B: its layer stack reads `per_layer_inp`, which the graph PROLOGUE builds, so a
         // span starting past layer 0 would read an unbound tensor. This is the gate for it — the
@@ -1825,10 +1821,8 @@ pub(crate) fn dense_placement_fits(
     v_fmt: DType,
 ) -> bool {
     let ring = placement_ring(cfg, ec, k_fmt, v_fmt);
-    // A RESIDENT session prefills chunk-major unless the user forced the other order, so the
-    // whole-prompt residual stream is priced only for the forced case. `Some(true)` is the sole
-    // value that reaches here as layer-major: unset means "on iff streaming", and a session that
-    // fits does not stream.
+    // Every session prefills chunk-major unless the user forces the other order, so the
+    // whole-prompt residual stream is priced only for the explicit `Some(true)` case.
     let lm = if ec.paging.layer_major == Some(true) {
         layer_major_act_bytes(cfg, want_ctx, ubatch)
     } else {
@@ -1872,13 +1866,12 @@ pub(crate) fn dense_stream_budget_at(
     v_fmt: DType,
 ) -> u64 {
     let ring = placement_ring(cfg, ec, k_fmt, v_fmt);
-    // A streamed session prefills LAYER-MAJOR by default, which holds every chunk's residual
-    // stream at once — those bytes come out of the same VRAM the arenas want, and they are
-    // allocated later, so the arena has to leave room for them (see `layer_major_act_bytes`).
-    let lm = if ec.paging.layer_major == Some(false) {
-        0
-    } else {
+    // Chunk-major is the default for streamed sessions too. Only an explicit layer-major request
+    // holds residual streams across layers, so only that mode reserves the extra bytes.
+    let lm = if ec.paging.layer_major == Some(true) {
         layer_major_act_bytes(cfg, want_ctx, ubatch)
+    } else {
+        0
     };
     planned_vram_room(vram, ec)
         .saturating_sub(dense_resident_need(
@@ -5554,6 +5547,41 @@ mod seam_helper_tests {
         );
     }
 
+    #[test]
+    fn layer_major_prefill_is_explicit_only() {
+        let caps = Capabilities {
+            graph_input_inplace: true,
+            ..Default::default()
+        };
+        let default_cfg = EngineConfig::default();
+        assert!(
+            !super::layer_major_prefill(&default_cfg, &caps, true),
+            "an unset setting must keep the chunk-major production order"
+        );
+
+        let enabled = EngineConfig {
+            paging: infr_core::config::PagingCfg {
+                layer_major: Some(true),
+                ..Default::default()
+            },
+            ..Default::default()
+        };
+        assert!(super::layer_major_prefill(&enabled, &caps, true));
+        assert!(
+            !super::layer_major_prefill(&enabled, &caps, false),
+            "an architecture that cannot split its stack stays chunk-major"
+        );
+
+        let disabled = EngineConfig {
+            paging: infr_core::config::PagingCfg {
+                layer_major: Some(false),
+                ..Default::default()
+            },
+            ..Default::default()
+        };
+        assert!(!super::layer_major_prefill(&disabled, &caps, true));
+    }
+
     fn deepseek4_cache_config() -> Config {
         Config {
             deepseek4: true,
@@ -6285,8 +6313,7 @@ mod seam_helper_tests {
         );
 
         // Streaming budget: exhausted at the ceiling, and it never offers the guard's headroom.
-        // A streamed session also prefills layer-major, whose whole-prompt residual stream is
-        // allocated AFTER the arenas out of the same VRAM — so the budget holds that back too.
+        // Chunk-major is the default and needs no cross-layer residual reservation.
         let lm = super::layer_major_act_bytes(&cfg, ctx, ub);
         assert!(
             lm > 0,
@@ -6312,14 +6339,13 @@ mod seam_helper_tests {
         );
         assert_eq!(
             budget(exact - (1 << 30)),
-            (1 << 30) - lm,
-            "and it is exactly the room below the ceiling less the residual stream, not the free \
-             figure"
+            1 << 30,
+            "the default chunk-major order keeps the whole room below the ceiling"
         );
-        // Forcing chunk-major back on gives those bytes to the arena, which is the knob's point.
-        let chunk_major = EngineConfig {
+        // Explicit layer-major is the only mode that holds the cross-layer residual stream back.
+        let layer_major = EngineConfig {
             paging: infr_core::config::PagingCfg {
-                layer_major: Some(false),
+                layer_major: Some(true),
                 ..ec.paging.clone()
             },
             ..ec.clone()
@@ -6328,7 +6354,7 @@ mod seam_helper_tests {
             super::dense_stream_budget_at(
                 &cfg,
                 &conservative_caps(),
-                &chunk_major,
+                &layer_major,
                 exact - (1 << 30),
                 &vram,
                 ctx,
@@ -6336,8 +6362,8 @@ mod seam_helper_tests {
                 f16.0,
                 f16.1
             ),
-            1 << 30,
-            "paging.layer_major = false takes the residual-stream reserve back off the budget"
+            (1 << 30) - lm,
+            "paging.layer_major = true reserves the residual stream explicitly"
         );
 
         // MoE expert placement: same ceiling, minus the model/shape-derived phase workspace.

--- a/crates/infr-llama/src/seam/model.rs
+++ b/crates/infr-llama/src/seam/model.rs
@@ -542,12 +542,10 @@ impl SeamModel {
     /// arena must fit the live free bytes. Paged MoE Experts contribute their one-layer arena
     /// floor rather than their full pageable payload. The rung ladder, in order:
     ///
-    ///  1. **f16 fits `want`** → use it, say nothing. (The overwhelmingly common case, and — since
-    ///     the fit now walks the same prefill-chunk ladder placement walks — the case gemma-3-12b
-    ///     at ctx 131072 belongs in and used to miss.)
-    ///  2. **f16 misses, q8_0 reaches `want`** → pin auto-q8 and `tracing::warn!`. Only a FULL
-    ///     rescue pins q8; a partial one keeps the predictable f16 cache, because auto-q8 exists
-    ///     to avoid losing capability, not to trade decode speed for a still-clamped window.
+    ///  1. **The selected KV format fits `want`** → use it, say nothing. Vulkan defaults an
+    ///     unset, compatible cache to Q8_0; an explicit format remains authoritative.
+    ///  2. **Legacy placement state can be rescued by q8_0** → retain the existing pin-and-warn
+    ///     compatibility rung before shrinking the context.
     ///  3. **`INFR_KV_OVERFLOW`** → keep `want` with the cache in system RAM.
     ///  4. **Nothing serves even [`MIN_SESSION_CTX`](crate::seam::MIN_SESSION_CTX)** → `Err`. The
     ///     weights leave no room for a usable cache on this device, so refusing with the numbers
@@ -575,6 +573,7 @@ impl SeamModel {
         // half the bytes per token. The fit math now prices MoE's pageable Experts separately, so
         // the same rescue is valid for dense and paged-MoE sessions.
         let may_auto_q8 = !crate::seam::kv_auto_q8()
+            && !crate::seam::kv_default_q8(&self.cfg, &self.ecfg)
             && crate::seam::kv_unset(&self.ecfg)
             && crate::seam::kv_q8_layout_ok(&self.cfg);
         let fit_q8 = may_auto_q8.then(|| self.kv_fit_ctx_fmt(vk, true)).flatten();
@@ -686,7 +685,7 @@ impl SeamModel {
     /// the backstop.
     fn kv_fit_ctx(&self, vk: &infr_vulkan::VulkanBackend) -> Option<usize> {
         // Price whatever the runner will actually allocate: the auto-q8 pin (if the placement
-        // ladder set it earlier in this process) or the plain env-driven formats.
+        // ladder set it earlier in this process) or the automatic/explicit formats.
         self.kv_fit_ctx_fmt(vk, crate::seam::kv_auto_q8())
     }
 
@@ -735,15 +734,16 @@ impl SeamModel {
     }
 
     /// The per-side KV dtypes a fit/footprint estimate must price: the user's explicit
-    /// `INFR_KV_TYPE_K`/`_V` when set, else the default ladder (legacy `INFR_KV_Q8`, then a
-    /// placement-pinned or candidate auto-q8, then f16) — the same ladder `parse_kv_fmt` walks in
-    /// the runner. ESTIMATE ONLY in one direction: the runner additionally gates each format on
+    /// `INFR_KV_TYPE_K`/`_V` when set, else the Vulkan default (Q8_0 on a compatible layout,
+    /// otherwise f16) — the same ladder `parse_kv_fmt` walks in the runner. ESTIMATE ONLY in one
+    /// direction: the runner additionally gates each format on
     /// backend/alignment and falls back to f16, so a gated-out low-bit request under-estimates
     /// here and the alloc-time VRAM guard backstops it.
     fn kv_fit_fmts(&self, auto_q8: bool) -> (DType, DType) {
+        let default_q8 = crate::seam::kv_default_q8(&self.cfg, &self.ecfg);
         let side = |want: Option<DType>| match want {
             Some(dt) => dt,
-            None if self.ecfg.kv.force_q8 || auto_q8 => DType::Q8_0,
+            None if self.ecfg.kv.force_q8 || auto_q8 || default_q8 => DType::Q8_0,
             None => DType::F16,
         };
         (side(self.ecfg.kv.type_k), side(self.ecfg.kv.type_v))

--- a/crates/infr-llama/src/seam/runner.rs
+++ b/crates/infr-llama/src/seam/runner.rs
@@ -599,30 +599,26 @@ pub(crate) fn generate_dense_backend(
     // env/file/CLI layer). A name nothing recognizes yields `None` here AND leaves `*_specified`
     // true, which is exactly today's split (§11 decision 8): it falls through to the ladder below
     // while still having suppressed auto-q8 up in the placement.
-    let parse_kv_fmt = |want: Option<DType>| -> DType {
-        match want {
-            Some(dt @ (DType::Turbo2 | DType::Turbo3 | DType::Turbo4)) if kv_turbo_ok => dt,
-            Some(DType::Q8_0) if kv_align_ok && kv_q8_backend => DType::Q8_0,
-            Some(dt @ (DType::Q4_0 | DType::Q4_1 | DType::Q5_0 | DType::Q5_1 | DType::Iq4Nl))
-                if blk_ok =>
-            {
-                dt
+    let automatic_q8 =
+        be.name() == "vulkan" && (crate::seam::kv_auto_q8() || crate::seam::kv_default_q8(c, ec));
+    let parse_kv_fmt =
+        |want: Option<DType>| -> DType {
+            match want {
+                Some(dt @ (DType::Turbo2 | DType::Turbo3 | DType::Turbo4)) if kv_turbo_ok => dt,
+                Some(DType::Q8_0) if kv_align_ok && kv_q8_backend => DType::Q8_0,
+                Some(
+                    dt @ (DType::Q4_0 | DType::Q4_1 | DType::Q5_0 | DType::Q5_1 | DType::Iq4Nl),
+                ) if blk_ok => dt,
+                Some(dt @ (DType::Bf16 | DType::F32)) if dense_ok => dt,
+                Some(DType::F16) => DType::F16,
+                // unset/unknown/gated-out → legacy `kv.force_q8` alias (both sides q8) or f16.
+                _ if ec.kv.force_q8 && kv_align_ok && kv_q8_backend => DType::Q8_0,
+                // Vulkan's automatic Q8 choice. Backend and layout gates keep it out of CPU/Metal and
+                // out of models whose cache rows cannot carry Q8_0 blocks.
+                _ if automatic_q8 && kv_align_ok => DType::Q8_0,
+                _ => DType::F16,
             }
-            Some(dt @ (DType::Bf16 | DType::F32)) if dense_ok => dt,
-            Some(DType::F16) => DType::F16,
-            // unset/unknown/gated-out → legacy `kv.force_q8` alias (both sides q8) or f16.
-            _ if ec.kv.force_q8 && kv_align_ok && kv_q8_backend => DType::Q8_0,
-            // Placement-pinned auto-q8 (see `crate::seam::PlacementPins`): the Vulkan placement
-            // chose a q8 cache to stay resident / keep the default ctx. Vulkan-gated — the pin
-            // is a Vulkan placement decision and must not leak into a CPU/Metal session (e.g.
-            // the CPU oracle of a parity test) running in the same process. The pin is only ever
-            // set when `kv_env_unset()` and `kv_q8_layout_ok` held, so the alignment/backend
-            // gates here re-check what already passed; the env being unset means no earlier arm
-            // can shadow this one.
-            _ if crate::seam::kv_auto_q8() && be.name() == "vulkan" && kv_align_ok => DType::Q8_0,
-            _ => DType::F16,
-        }
-    };
+        };
     let mut k_fmt = parse_kv_fmt(ec.kv.type_k);
     let mut v_fmt = parse_kv_fmt(ec.kv.type_v);
     // Metal's Q8 and F32 KV use native-read attention that reads BOTH sides as one dtype, so a
@@ -1320,13 +1316,22 @@ pub(crate) fn generate_dense_backend(
         // arena. Its buffers therefore keep the requested logical extent and commit physical 32K
         // segments on demand; applying the flat-buffer live-room clamp would price those bytes a
         // second time. Every other session retains the existing measured clamp unchanged.
-        let segmented_kv = ec.kv.dynamic
+        let segmented_available = be.segmented_kv_available();
+        let segmented_kv =
+            crate::seam::segmented_kv_wanted(c, ec, kv_ring, k_fmt, v_fmt) && segmented_available;
+        if ec.kv.dynamic
             && (c.qwen35 || c.qwen4exp)
             && !kv_ring
             && !ec.kv.overflow
-            && matches!(k_fmt, DType::F16 | DType::Q8_0)
-            && matches!(v_fmt, DType::F16 | DType::Q8_0)
-            && be.segmented_kv_available();
+            && segmented_available
+            && !segmented_kv
+        {
+            tracing::info!(
+                k_dtype = ?k_fmt,
+                v_dtype = ?v_fmt,
+                "dynamic KV currently requires Q8_0/Q8_0; using flat KV"
+            );
+        }
         let want_ctx = if segmented_kv {
             want_ctx
         } else {
@@ -7495,13 +7500,13 @@ pub(crate) fn generate_dense_backend(
         // Both halves of what a prefill holds live, so the comparison stays honest in either
         // order: per-chunk scratch plus the layer-major residual set (whole prompt normally,
         // one bounded group on Qwen3.8), exactly as priced during placement.
-        let reserved = crate::seam::dense_act_reserve_at(c, &caps, max_ctx, rows).saturating_add(
-            if crate::seam::layer_major_prefill(ec, &caps, !e2b) {
-                crate::seam::layer_major_act_bytes(c, max_ctx, rows)
-            } else {
-                0
-            },
-        );
+        let reserved =
+            crate::seam::runtime_reserve_at(c, &caps, max_ctx, kv_ring, rows, k_fmt, v_fmt)
+                .saturating_add(if crate::seam::layer_major_prefill(ec, &caps, !e2b) {
+                    crate::seam::layer_major_act_bytes(c, max_ctx, rows)
+                } else {
+                    0
+                });
         // RUST_LOG=debug turns this into the measurement the reserve is re-fit against; the WARN
         // below is what a user sees when the prediction was wrong in the direction that hurts.
         tracing::debug!(

--- a/crates/infr-llama/src/seam/runner.rs
+++ b/crates/infr-llama/src/seam/runner.rs
@@ -5,10 +5,12 @@
 use super::sc::{
     build_sc_embt, diffusion_self_cond, DenoiseCache, DenoiseReq, EbReduced, SelfCondWeights,
 };
+use super::segmented_kv::{PlaneKind, SegmentedKvLayout};
 use super::weights::{
-    AttnW, DeltaW, Dsv4CompressedW, Dsv4CompressorW, Dsv4IndexerW, Dsv4W, FfnW, HcTriple, IndexerW,
-    KdaW, LayerHcW, LayerW, MixerW, MlaW, MoeSharedW, QsaW, QwenHcW, QwenLayerHcW, QwenPleW,
-    SeamKv, SeamWeights, SessionStable, TurnRecurrentCkpt,
+    alloc_segmented_plane, AttnW, DeltaW, Dsv4CompressedW, Dsv4CompressorW, Dsv4IndexerW, Dsv4W,
+    FfnW, HcTriple, IndexerW, KdaW, LayerHcW, LayerW, MixerW, MlaW, MoeSharedW, QsaW, QwenHcW,
+    QwenLayerHcW, QwenPleW, SeamKv, SeamWeights, SegmentedKvState, SessionStable,
+    TurnRecurrentCkpt,
 };
 use super::{
     common_prefix_len, e2b_ipl_rows, kv_forces_static, BindWeight, TurnCheckpoint, WBytes,
@@ -1320,11 +1322,26 @@ pub(crate) fn generate_dense_backend(
         // the measured-room context clamp and exact KV/state allocations below. Other backends keep
         // the default no-op.
         be.finish_weight_load().map_err(|e| anyhow!("{e}"))?;
-        // Every weight this session will hold is resident by now — including the arena block tails
-        // and the driver's own memory that no pre-load footprint prices — so the budget query here
-        // is a MEASUREMENT where the clamp that sized `want_ctx` could only estimate. Shrinks only,
-        // and never a context the user pinned. See `reclamp_ctx_to_live_room`.
-        let want_ctx = crate::seam::reclamp_ctx_to_live_room(be, c, ec, want_ctx, k_fmt, v_fmt);
+        // A paged Qwen session reserves its maximum per-token state inside the unified elastic
+        // arena. Its buffers therefore keep the requested logical extent and commit physical 32K
+        // segments on demand; applying the flat-buffer live-room clamp would price those bytes a
+        // second time. Every other session retains the existing measured clamp unchanged.
+        let segmented_kv = ec.kv.dynamic
+            && c.qwen35
+            && !kv_ring
+            && !ec.kv.overflow
+            && matches!(k_fmt, DType::F16 | DType::Q8_0)
+            && matches!(v_fmt, DType::F16 | DType::Q8_0)
+            && be.segmented_kv_available();
+        let want_ctx = if segmented_kv {
+            want_ctx
+        } else {
+            crate::seam::reclamp_ctx_to_live_room(be, c, ec, want_ctx, k_fmt, v_fmt)
+        };
+        let segmented_layout = segmented_kv.then(|| {
+            SegmentedKvLayout::for_qwen(c, want_ctx, k_fmt, v_fmt)
+                .expect("qwen35 has segmented KV geometry")
+        });
 
         // ── persistent KV cache buffers, sized per-layer (gemma4 SWA layers are narrower) and
         //    per-side (K and V pick their dtype independently) ────────────────────────────────
@@ -1366,12 +1383,26 @@ pub(crate) fn generate_dense_backend(
                 v_fmt,
             );
             kbufs.push(
-                be.alloc(k_bytes, BufferUsage::KvCache)
-                    .map_err(|e| anyhow!("{e}"))?,
+                if let Some(layout) = segmented_layout
+                    .as_ref()
+                    .filter(|layout| layout.plane(l, PlaneKind::K).is_some())
+                {
+                    alloc_segmented_plane(be, layout, l, PlaneKind::K)?
+                } else {
+                    be.alloc(k_bytes, BufferUsage::KvCache)
+                        .map_err(|e| anyhow!("{e}"))?
+                },
             );
             vbufs.push(
-                be.alloc(v_bytes, BufferUsage::KvCache)
-                    .map_err(|e| anyhow!("{e}"))?,
+                if let Some(layout) = segmented_layout
+                    .as_ref()
+                    .filter(|layout| layout.plane(l, PlaneKind::V).is_some())
+                {
+                    alloc_segmented_plane(be, layout, l, PlaneKind::V)?
+                } else {
+                    be.alloc(v_bytes, BufferUsage::KvCache)
+                        .map_err(|e| anyhow!("{e}"))?
+                },
             );
             let qsa_bytes = crate::seam::qsa_raw_cache_bytes(c, l, want_ctx);
             qsa_kbufs.push(if qsa_bytes > 0 {
@@ -1491,6 +1522,11 @@ pub(crate) fn generate_dense_backend(
             vbufs,
             qsa_kbufs,
             qsa_cbufs,
+            segmented_kv: if segmented_kv {
+                SegmentedKvState::enabled()
+            } else {
+                SegmentedKvState::default()
+            },
             k_fmt,
             v_fmt,
             hidden_buf,
@@ -1539,6 +1575,7 @@ pub(crate) fn generate_dense_backend(
         vbufs,
         qsa_kbufs,
         qsa_cbufs,
+        segmented_kv,
         k_fmt: _,
         v_fmt: _,
         hidden_buf,
@@ -1562,6 +1599,7 @@ pub(crate) fn generate_dense_backend(
         // so the struct field is only read by fork/seed (which have no backend caps at hand).
         kv_ring: _,
     } = state.as_mut().expect("seam state just initialized");
+    let segmented_kv_enabled = segmented_kv.enabled;
     let SeamWeights {
         wbufs,
         wspecs,
@@ -1578,6 +1616,22 @@ pub(crate) fn generate_dense_backend(
             prompt.len(),
             max_new
         ));
+    }
+    macro_rules! ensure_kv_depth {
+        ($tokens:expr) => {
+            segmented_kv.ensure_depth(
+                be,
+                c,
+                max_ctx,
+                k_fmt,
+                v_fmt,
+                &kbufs[..],
+                &vbufs[..],
+                &qsa_kbufs[..],
+                &qsa_cbufs[..],
+                $tokens,
+            )?
+        };
     }
     // Ordinary (non-denoise) generation needs a non-empty prompt (the `.min(prompt.len()-1)`
     // prefix-diff below would underflow on empty, and there'd be nothing to sample the first
@@ -1912,7 +1966,7 @@ pub(crate) fn generate_dense_backend(
         // graph is ever replay-eligible anyway (batched prefill/denoise are rows>1), and DG has
         // no autoregressive decode loop — its per-prefill decode is exactly one token — so this
         // costs nothing while making both modes bit-identical.
-        g.no_decode_replay = c.diffusion_gemma || c.qwen4exp;
+        g.no_decode_replay = c.diffusion_gemma || c.qwen4exp || segmented_kv_enabled;
         let f32d = |n: usize| TensorDesc::new(vec![n], DType::F32);
         // KV cache dtype: f16 by default (halves memory vs f32, tightens CPU↔GPU parity); Q8_0
         // per-side when the runner enabled it (see `k_fmt`/`v_fmt` at the cache alloc). ONLY the
@@ -6231,6 +6285,7 @@ pub(crate) fn generate_dense_backend(
         if let (Some(ho), Some(hb)) = (vh.h_out, &vf_h_buf) {
             vb.bind(ho, hb.as_ref());
         }
+        ensure_kv_depth!(start + m);
         let t0 = std::time::Instant::now();
         be.execute(vplan.as_ref(), &vb)
             .map_err(|e| anyhow!("{e}"))?;
@@ -6534,6 +6589,7 @@ pub(crate) fn generate_dense_backend(
                         } else {
                             req.and_then(|r| r.gate_pass())
                         };
+                        ensure_kv_depth!(cend);
                         let pf_m = cend - cstart;
                         if live[ci].is_none() {
                             // GPU embed gather: upload the chunk's token IDS (4*pf_m bytes) — the graph's
@@ -6796,6 +6852,7 @@ pub(crate) fn generate_dense_backend(
     let dyn_replay = caps.decode_replay
         && !be.moe_paged()
         && !be.dense_paged()
+        && !segmented_kv_enabled
         && !ec.kernels.vulkan.no_replay
         // DiffusionGemma graphs opt out of the replay tape entirely (`Graph::no_decode_replay`,
         // set in `build` above — the adapter's `decode_eligible` rejects them, this mirror just
@@ -6952,6 +7009,7 @@ pub(crate) fn generate_dense_backend(
         // can be head-of-line blocked behind another's whole generation, only behind one step of it.
         // `req` None (run/bench/tests) constructs nothing.
         let _gp = req.and_then(|r| r.gate_pass());
+        ensure_kv_depth!(pos + 1);
         if can_chain && pos + 1 >= prompt.len() && pos + 1 == cur.len() && logits_out.is_none() {
             // Clamped by the backend's watchdog budget too: a chain is one submit of `n` decode
             // steps, and on a slow device that submit has to stay short (see

--- a/crates/infr-llama/src/seam/runner.rs
+++ b/crates/infr-llama/src/seam/runner.rs
@@ -1406,19 +1406,23 @@ pub(crate) fn generate_dense_backend(
             );
             let qsa_bytes = crate::seam::qsa_raw_cache_bytes(c, l, want_ctx);
             qsa_kbufs.push(if qsa_bytes > 0 {
-                Some(
+                Some(if let Some(layout) = segmented_layout.as_ref() {
+                    alloc_segmented_plane(be, layout, l, PlaneKind::QsaRaw)?
+                } else {
                     be.alloc(qsa_bytes, BufferUsage::KvCache)
-                        .map_err(|e| anyhow!("{e}"))?,
-                )
+                        .map_err(|e| anyhow!("{e}"))?
+                })
             } else {
                 None
             });
             let qsa_comp_bytes = crate::seam::qsa_block_cache_bytes(c, l, want_ctx);
             qsa_cbufs.push(if qsa_comp_bytes > 0 {
-                Some(
+                Some(if let Some(layout) = segmented_layout.as_ref() {
+                    alloc_segmented_plane(be, layout, l, PlaneKind::QsaBlock)?
+                } else {
                     be.alloc(qsa_comp_bytes, BufferUsage::KvCache)
-                        .map_err(|e| anyhow!("{e}"))?,
-                )
+                        .map_err(|e| anyhow!("{e}"))?
+                })
             } else {
                 None
             });

--- a/crates/infr-llama/src/seam/runner.rs
+++ b/crates/infr-llama/src/seam/runner.rs
@@ -341,10 +341,6 @@ fn session_stable(
                 })
             }
     };
-    let qwen_grid_experts = c.qwen4exp
-        && g.tensors().iter().any(|t| {
-            t.name.ends_with("_exps.weight") && matches!(t.dtype, DType::Iq2Xs | DType::Iq3Xxs)
-        });
     Ok(SessionStable {
         has_wv,
         out_scale,
@@ -354,7 +350,6 @@ fn session_stable(
         fuse_gu,
         fuse_qkv,
         moe_batched_ok,
-        qwen_grid_experts,
     })
 }
 
@@ -527,7 +522,6 @@ pub(crate) fn generate_dense_backend(
     let fuse_gu = stable.fuse_gu;
     let fuse_qkv = stable.fuse_qkv;
     let moe_batched_ok = stable.moe_batched_ok;
-    let qwen_grid_experts = stable.qwen_grid_experts;
 
     // qwen35 DeltaNet silu-gated RMSNorm fusion (decode op-fusion campaign): QkNorm's per-head
     // rmsnorm write is immediately read-after-write by the z-gate GatedAct — a real barrier on
@@ -6501,16 +6495,10 @@ pub(crate) fn generate_dense_backend(
         // SWA ring is untouched by the reorder — its bound is per layer and per dispatch
         // ("window + one chunk", see `kv_rows`), and each layer's ring still sees exactly the same
         // ascending sequence of writes it saw chunk-major.
-        // A single Qwen3.8 chunk has no repeated expert sweep to amortize: splitting it into one
-        // execute per layer only inserts 48 queue-drain boundaries. Enable the MoE-driven
-        // layer-major order when there are multiple chunks; dense paging keeps its established
-        // behavior because it may need the order even for one chunk.
-        let qwen_moe_streaming = c.qwen4exp
-            && qwen_grid_experts
-            && be.moe_paged()
-            && pf_end.saturating_sub(start) > ubatch;
-        let streaming = be.dense_paged() || qwen_moe_streaming;
-        let layer_major = crate::seam::layer_major_prefill(ec, &caps, streaming, !e2b);
+        // Chunk-major is the production default. Layer-major remains an explicit A/B mode: on
+        // paged Qwen3.8 it measured more than an order of magnitude slower because it turns one
+        // whole-model chunk into per-layer execute/queue-drain boundaries.
+        let layer_major = crate::seam::layer_major_prefill(ec, &caps, !e2b);
         let spans: Vec<std::ops::Range<usize>> = if layer_major {
             (0..c.n_layer).map(|l| l..l + 1).collect()
         } else {
@@ -7504,15 +7492,11 @@ pub(crate) fn generate_dense_backend(
     // that does not hold.
     if let Some(peak) = be.activation_peak() {
         let rows = crate::seam::ubatch_rows(ec);
-        let qwen_grouped = c.qwen4exp
-            && qwen_grid_experts
-            && be.moe_paged()
-            && prompt.len().saturating_sub(1).saturating_sub(start) > rows;
         // Both halves of what a prefill holds live, so the comparison stays honest in either
         // order: per-chunk scratch plus the layer-major residual set (whole prompt normally,
         // one bounded group on Qwen3.8), exactly as priced during placement.
         let reserved = crate::seam::dense_act_reserve_at(c, &caps, max_ctx, rows).saturating_add(
-            if crate::seam::layer_major_prefill(ec, &caps, be.dense_paged() || qwen_grouped, !e2b) {
+            if crate::seam::layer_major_prefill(ec, &caps, !e2b) {
                 crate::seam::layer_major_act_bytes(c, max_ctx, rows)
             } else {
                 0

--- a/crates/infr-llama/src/seam/runner.rs
+++ b/crates/infr-llama/src/seam/runner.rs
@@ -1327,7 +1327,7 @@ pub(crate) fn generate_dense_backend(
         // segments on demand; applying the flat-buffer live-room clamp would price those bytes a
         // second time. Every other session retains the existing measured clamp unchanged.
         let segmented_kv = ec.kv.dynamic
-            && c.qwen35
+            && (c.qwen35 || c.qwen4exp)
             && !kv_ring
             && !ec.kv.overflow
             && matches!(k_fmt, DType::F16 | DType::Q8_0)
@@ -1340,7 +1340,7 @@ pub(crate) fn generate_dense_backend(
         };
         let segmented_layout = segmented_kv.then(|| {
             SegmentedKvLayout::for_qwen(c, want_ctx, k_fmt, v_fmt)
-                .expect("qwen35 has segmented KV geometry")
+                .expect("Qwen hybrid models have segmented KV geometry")
         });
 
         // ── persistent KV cache buffers, sized per-layer (gemma4 SWA layers are narrower) and

--- a/crates/infr-llama/src/seam/segmented_kv.rs
+++ b/crates/infr-llama/src/seam/segmented_kv.rs
@@ -5,11 +5,8 @@
 //! steps, while recurrent layers remain fixed-size state and attention/QSA planes commit only the
 //! segments their materialized token depth reaches.
 
-// This first commit fixes the geometry contract before the allocator consumes it. Remove this
-// allowance in the wiring commit, where every item below enters the production path.
-#![allow(dead_code)]
-
 use crate::Config;
+use infr_core::backend::SegmentedKvSpec;
 use infr_core::tensor::DType;
 
 use super::{kv_row_elems, kv_side_bytes};
@@ -44,6 +41,26 @@ impl PlaneLayout {
 
     pub(crate) fn segment_bytes(self) -> usize {
         kv_side_bytes(self.dtype, self.rows_per_segment() * self.row_elems)
+    }
+
+    pub(crate) fn segment_elements(self) -> usize {
+        self.rows_per_segment() * self.row_elems
+    }
+
+    pub(crate) fn logical_elements(self, max_ctx: usize) -> usize {
+        let rows = (max_ctx / self.tokens_per_row).max(1);
+        rows * self.row_elems
+    }
+
+    pub(crate) fn spec(self, max_ctx: usize) -> SegmentedKvSpec {
+        let segment_elements = self.segment_elements();
+        debug_assert!(segment_elements.is_power_of_two());
+        SegmentedKvSpec {
+            logical_bytes: kv_side_bytes(self.dtype, self.logical_elements(max_ctx)),
+            segment_bytes: self.segment_bytes(),
+            segment_elements,
+            max_segments: max_ctx.div_ceil(KV_GROW_ROWS),
+        }
     }
 }
 
@@ -113,6 +130,7 @@ impl SegmentedKvLayout {
         Some(Self { max_ctx, planes })
     }
 
+    #[cfg(test)]
     pub(crate) fn max_segments(&self) -> usize {
         self.max_ctx.div_ceil(KV_GROW_ROWS)
     }
@@ -127,6 +145,13 @@ impl SegmentedKvLayout {
             .iter()
             .map(|plane| plane.segment_bytes() as u64 * segments)
             .sum()
+    }
+
+    pub(crate) fn plane(&self, layer: usize, kind: PlaneKind) -> Option<PlaneLayout> {
+        self.planes
+            .iter()
+            .copied()
+            .find(|plane| plane.layer == layer && plane.kind == kind)
     }
 }
 

--- a/crates/infr-llama/src/seam/segmented_kv.rs
+++ b/crates/infr-llama/src/seam/segmented_kv.rs
@@ -1,0 +1,228 @@
+//! Pure geometry for lazily committed KV storage.
+//!
+//! This module deliberately owns no buffers and changes no execution path. It is the arithmetic
+//! contract shared by the later allocator and Vulkan work: a conversation grows in 32K-token
+//! steps, while recurrent layers remain fixed-size state and attention/QSA planes commit only the
+//! segments their materialized token depth reaches.
+
+// This first commit fixes the geometry contract before the allocator consumes it. Remove this
+// allowance in the wiring commit, where every item below enters the production path.
+#![allow(dead_code)]
+
+use crate::Config;
+use infr_core::tensor::DType;
+
+use super::{kv_row_elems, kv_side_bytes};
+
+/// Public runtime policy: persistent per-token state grows in 32K-token increments.
+pub(crate) const KV_GROW_ROWS: usize = 32 * 1024;
+
+#[derive(Clone, Copy, Debug, PartialEq, Eq)]
+pub(crate) enum PlaneKind {
+    K,
+    V,
+    QsaRaw,
+    QsaBlock,
+}
+
+/// One independently addressed cache plane in one model layer.
+#[derive(Clone, Copy, Debug, PartialEq, Eq)]
+pub(crate) struct PlaneLayout {
+    pub(crate) layer: usize,
+    pub(crate) kind: PlaneKind,
+    pub(crate) dtype: DType,
+    pub(crate) row_elems: usize,
+    /// Number of model tokens represented by one row. Ordinary K/V and QSA-raw rows use one;
+    /// QSA block keys use the layer's compression ratio.
+    pub(crate) tokens_per_row: usize,
+}
+
+impl PlaneLayout {
+    pub(crate) fn rows_per_segment(self) -> usize {
+        KV_GROW_ROWS / self.tokens_per_row
+    }
+
+    pub(crate) fn segment_bytes(self) -> usize {
+        kv_side_bytes(self.dtype, self.rows_per_segment() * self.row_elems)
+    }
+}
+
+/// Model-level description of the per-token planes that may grow lazily. Fixed recurrent state is
+/// intentionally absent: it remains allocated once per conversation and does not scale with depth.
+#[derive(Clone, Debug, PartialEq, Eq)]
+pub(crate) struct SegmentedKvLayout {
+    pub(crate) max_ctx: usize,
+    pub(crate) planes: Vec<PlaneLayout>,
+}
+
+impl SegmentedKvLayout {
+    /// Build the layout used by the first implementation target: Qwen3.5/3.6 hybrid attention and
+    /// Qwen3.8 full-attention/QSA layers. Other architectures keep their existing static cache.
+    pub(crate) fn for_qwen(
+        cfg: &Config,
+        max_ctx: usize,
+        k_fmt: DType,
+        v_fmt: DType,
+    ) -> Option<Self> {
+        if !(cfg.qwen35 || cfg.qwen4exp) {
+            return None;
+        }
+        let mut planes = Vec::new();
+        for layer in 0..cfg.n_layer {
+            if cfg.is_recurrent_layer(layer) {
+                continue;
+            }
+            let (k_row, v_row) = kv_row_elems(cfg, layer);
+            if k_row != 0 {
+                planes.push(PlaneLayout {
+                    layer,
+                    kind: PlaneKind::K,
+                    dtype: k_fmt,
+                    row_elems: k_row,
+                    tokens_per_row: 1,
+                });
+            }
+            if v_row != 0 {
+                planes.push(PlaneLayout {
+                    layer,
+                    kind: PlaneKind::V,
+                    dtype: v_fmt,
+                    row_elems: v_row,
+                    tokens_per_row: 1,
+                });
+            }
+            if cfg.qwen4exp && cfg.is_qwen_hybrid_attn_layer(layer) {
+                planes.push(PlaneLayout {
+                    layer,
+                    kind: PlaneKind::QsaRaw,
+                    dtype: DType::F16,
+                    row_elems: cfg.indexer_head_size,
+                    tokens_per_row: 1,
+                });
+                let ratio = cfg.layer_compress_ratio(layer).max(1);
+                debug_assert!(KV_GROW_ROWS.is_multiple_of(ratio));
+                planes.push(PlaneLayout {
+                    layer,
+                    kind: PlaneKind::QsaBlock,
+                    dtype: DType::F32,
+                    row_elems: cfg.indexer_head_size,
+                    tokens_per_row: ratio,
+                });
+            }
+        }
+        Some(Self { max_ctx, planes })
+    }
+
+    pub(crate) fn max_segments(&self) -> usize {
+        self.max_ctx.div_ceil(KV_GROW_ROWS)
+    }
+
+    pub(crate) fn segments_for_tokens(&self, tokens: usize) -> usize {
+        tokens.min(self.max_ctx).div_ceil(KV_GROW_ROWS)
+    }
+
+    pub(crate) fn committed_bytes(&self, tokens: usize) -> u64 {
+        let segments = self.segments_for_tokens(tokens) as u64;
+        self.planes
+            .iter()
+            .map(|plane| plane.segment_bytes() as u64 * segments)
+            .sum()
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    fn qwen38() -> Config {
+        Config {
+            qwen4exp: true,
+            n_layer: 48,
+            recurrent_layers: (0usize..48)
+                .map(|layer| !(layer + 1).is_multiple_of(4))
+                .collect(),
+            compress_ratios: (0usize..48)
+                .map(|layer| if (layer + 1).is_multiple_of(4) { 4 } else { 0 })
+                .collect(),
+            n_kv: 2,
+            head_dim: 256,
+            indexer_head_size: 128,
+            ..Default::default()
+        }
+    }
+
+    #[test]
+    fn depth_crosses_exactly_one_32k_boundary() {
+        let layout =
+            SegmentedKvLayout::for_qwen(&qwen38(), 262_144, DType::Q8_0, DType::Q8_0).unwrap();
+        assert_eq!(layout.max_segments(), 8);
+        assert_eq!(layout.segments_for_tokens(0), 0);
+        assert_eq!(layout.segments_for_tokens(KV_GROW_ROWS - 1), 1);
+        assert_eq!(layout.segments_for_tokens(KV_GROW_ROWS), 1);
+        assert_eq!(layout.segments_for_tokens(KV_GROW_ROWS + 1), 2);
+        assert_eq!(
+            layout.committed_bytes(KV_GROW_ROWS + 1),
+            2 * layout.committed_bytes(1)
+        );
+    }
+
+    #[test]
+    fn qwen38_layout_contains_only_twelve_attention_layers() {
+        let layout =
+            SegmentedKvLayout::for_qwen(&qwen38(), 262_144, DType::Q8_0, DType::Q8_0).unwrap();
+        assert_eq!(layout.planes.len(), 12 * 4);
+        assert_eq!(
+            layout
+                .planes
+                .iter()
+                .filter(|plane| plane.kind == PlaneKind::QsaBlock)
+                .count(),
+            12
+        );
+        assert!(layout
+            .planes
+            .iter()
+            .filter(|plane| plane.kind == PlaneKind::QsaBlock)
+            .all(|plane| plane.rows_per_segment() == KV_GROW_ROWS / 4));
+    }
+
+    #[test]
+    fn q8_segment_bytes_use_a_local_quant_scale_plane() {
+        let cfg = qwen38();
+        let layout = SegmentedKvLayout::for_qwen(&cfg, 262_144, DType::Q8_0, DType::Q8_0).unwrap();
+        let k = layout
+            .planes
+            .iter()
+            .find(|plane| plane.kind == PlaneKind::K)
+            .copied()
+            .unwrap();
+        assert_eq!(k.row_elems, cfg.n_kv * cfg.head_dim);
+        assert_eq!(
+            k.segment_bytes(),
+            infr_core::budget::kv_fmt_bytes(DType::Q8_0, KV_GROW_ROWS * k.row_elems)
+        );
+    }
+
+    #[test]
+    fn fully_committed_qwen38_planes_equal_the_existing_static_geometry() {
+        let cfg = qwen38();
+        let ctx = 262_144;
+        let layout = SegmentedKvLayout::for_qwen(&cfg, ctx, DType::Q8_0, DType::Q8_0).unwrap();
+        let static_bytes: u64 = (0..cfg.n_layer)
+            .filter(|&layer| !cfg.is_recurrent_layer(layer))
+            .map(|layer| {
+                let (k, v) = super::super::layer_state_bytes(
+                    &cfg,
+                    layer,
+                    ctx,
+                    false,
+                    1024,
+                    DType::Q8_0,
+                    DType::Q8_0,
+                );
+                (k + v + super::super::qsa_cache_bytes(&cfg, layer, ctx)) as u64
+            })
+            .sum();
+        assert_eq!(layout.committed_bytes(ctx), static_bytes);
+    }
+}

--- a/crates/infr-llama/src/seam/weights.rs
+++ b/crates/infr-llama/src/seam/weights.rs
@@ -365,8 +365,6 @@ pub(crate) struct SessionStable {
     pub(super) fuse_qkv: bool,
     /// Whether the MoE expert banks all have a dp4a-mmq kernel (batched-prefill eligibility).
     pub(super) moe_batched_ok: bool,
-    /// Qwen3.8 expert banks whose large MMQ scratch requires bounded layer-major prompt groups.
-    pub(super) qwen_grid_experts: bool,
 }
 
 pub(crate) struct SeamKv {

--- a/crates/infr-llama/src/seam/weights.rs
+++ b/crates/infr-llama/src/seam/weights.rs
@@ -1,6 +1,7 @@
 //! Per-layer weight handles + the persistent seam session state ([`SeamKv`]/[`SeamWeights`]).
 //! Pure-move split of `seam.rs` — see `super` for the module overview.
 use super::sc::{DenoiseCache, SelfCondWeights};
+use super::segmented_kv::{PlaneKind, SegmentedKvLayout, KV_GROW_ROWS};
 use super::{common_prefix_len, kv_fmt_bytes};
 use crate::Config;
 use anyhow::{anyhow, Result as AResult};
@@ -381,6 +382,9 @@ pub(crate) struct SeamKv {
     pub(super) qsa_kbufs: Vec<Option<Box<dyn Buffer>>>,
     /// Qwen3.8 QSA final block-key cache. Each complete compressed block owns one F32 row.
     pub(super) qsa_cbufs: Vec<Option<Box<dyn Buffer>>>,
+    /// Lazily committed Qwen KV state. The graph still sees the full logical context, while this
+    /// tracks how many 32K-token physical segments are currently backed by the unified arena.
+    pub(super) segmented_kv: SegmentedKvState,
     /// KV cache element dtypes, chosen per-side (K and V independent). Fork/seed reuse them so a
     /// forked slot sizes + copies its buffers to match this slot's layout.
     pub(super) k_fmt: DType,
@@ -451,6 +455,123 @@ pub(crate) struct SeamKv {
     /// prefill only the prior visible answer plus the new user turn, even when chat-history
     /// normalization makes the newly rendered prompt diverge from `cached`.
     pub(super) turn_recurrent_ckpt: Option<TurnRecurrentCkpt>,
+}
+
+#[derive(Default)]
+pub(super) struct SegmentedKvState {
+    pub(super) enabled: bool,
+    committed_tokens: usize,
+}
+
+impl SegmentedKvState {
+    pub(super) fn enabled() -> Self {
+        Self {
+            enabled: true,
+            committed_tokens: 0,
+        }
+    }
+
+    /// Commit every per-token plane through `tokens`. The fast path is one comparison; allocation
+    /// and address-table updates happen only when a call crosses a 32K-token boundary.
+    pub(super) fn ensure_depth(
+        &mut self,
+        be: &dyn Backend,
+        cfg: &Config,
+        max_ctx: usize,
+        k_fmt: DType,
+        v_fmt: DType,
+        kbufs: &[Box<dyn Buffer>],
+        vbufs: &[Box<dyn Buffer>],
+        qsa_kbufs: &[Option<Box<dyn Buffer>>],
+        qsa_cbufs: &[Option<Box<dyn Buffer>>],
+        tokens: usize,
+    ) -> AResult<()> {
+        if !self.enabled || tokens <= self.committed_tokens {
+            return Ok(());
+        }
+        if tokens > max_ctx {
+            return Err(anyhow!(
+                "KV depth {tokens} exceeds the session capacity {max_ctx}"
+            ));
+        }
+        let layout = SegmentedKvLayout::for_qwen(cfg, max_ctx, k_fmt, v_fmt)
+            .ok_or_else(|| anyhow!("segmented KV enabled for a non-Qwen session"))?;
+        let segments = layout.segments_for_tokens(tokens);
+        for plane in &layout.planes {
+            let buffer: &dyn Buffer = match plane.kind {
+                PlaneKind::K => kbufs[plane.layer].as_ref(),
+                PlaneKind::V => vbufs[plane.layer].as_ref(),
+                PlaneKind::QsaRaw => qsa_kbufs[plane.layer]
+                    .as_deref()
+                    .ok_or_else(|| anyhow!("missing QSA raw cache for layer {}", plane.layer))?,
+                PlaneKind::QsaBlock => qsa_cbufs[plane.layer]
+                    .as_deref()
+                    .ok_or_else(|| anyhow!("missing QSA block cache for layer {}", plane.layer))?,
+            };
+            be.ensure_segmented_kv(buffer, segments).map_err(|e| {
+                anyhow!(
+                    "commit segmented KV layer {} {:?}: {e}",
+                    plane.layer,
+                    plane.kind
+                )
+            })?;
+        }
+        self.committed_tokens = (segments * KV_GROW_ROWS).min(max_ctx);
+        tracing::info!(
+            requested_tokens = tokens,
+            committed_tokens = self.committed_tokens,
+            segments,
+            "expanded dynamic KV cache"
+        );
+        Ok(())
+    }
+
+    fn clear(
+        &self,
+        be: &dyn Backend,
+        cfg: &Config,
+        kbufs: &[Box<dyn Buffer>],
+        vbufs: &[Box<dyn Buffer>],
+        qsa_kbufs: &[Option<Box<dyn Buffer>>],
+        qsa_cbufs: &[Option<Box<dyn Buffer>>],
+    ) -> AResult<()> {
+        if !self.enabled {
+            return Ok(());
+        }
+        for layer in 0..cfg.n_layer {
+            if !cfg.is_recurrent_layer(layer) {
+                be.clear_segmented_kv(kbufs[layer].as_ref())
+                    .map_err(|e| anyhow!("clear segmented K cache at layer {layer}: {e}"))?;
+                be.clear_segmented_kv(vbufs[layer].as_ref())
+                    .map_err(|e| anyhow!("clear segmented V cache at layer {layer}: {e}"))?;
+            }
+            for (name, buffer) in [
+                ("QSA raw", qsa_kbufs[layer].as_deref()),
+                ("QSA block", qsa_cbufs[layer].as_deref()),
+            ] {
+                if let Some(buffer) = buffer {
+                    be.clear_segmented_kv(buffer).map_err(|e| {
+                        anyhow!("clear segmented {name} cache at layer {layer}: {e}")
+                    })?;
+                }
+            }
+        }
+        Ok(())
+    }
+}
+
+pub(super) fn alloc_segmented_plane(
+    be: &dyn Backend,
+    layout: &SegmentedKvLayout,
+    layer: usize,
+    kind: PlaneKind,
+) -> AResult<Box<dyn Buffer>> {
+    let plane = layout
+        .plane(layer, kind)
+        .ok_or_else(|| anyhow!("missing segmented KV geometry for layer {layer} {kind:?}"))?;
+    be.alloc_segmented_kv(plane.spec(layout.max_ctx))
+        .map_err(|e| anyhow!("allocate segmented KV layer {layer} {kind:?}: {e}"))?
+        .ok_or_else(|| anyhow!("segmented KV support disappeared while allocating the session"))
 }
 
 /// The device-resident DeltaNet-state snapshot backing [`SeamKv::mtp_snapshot_delta`] — one
@@ -676,6 +797,26 @@ impl SeamKv {
                 self.max_ctx
             ));
         }
+        self.segmented_kv.ensure_depth(
+            be,
+            cfg,
+            self.max_ctx,
+            self.k_fmt,
+            self.v_fmt,
+            &self.kbufs,
+            &self.vbufs,
+            &self.qsa_kbufs,
+            &self.qsa_cbufs,
+            tokens.len(),
+        )?;
+        self.segmented_kv.clear(
+            be,
+            cfg,
+            &self.kbufs,
+            &self.vbufs,
+            &self.qsa_kbufs,
+            &self.qsa_cbufs,
+        )?;
         if cfg.qwen35 || cfg.qwen4exp || cfg.bailingmoe3 {
             let conv_elems = (cfg.ssm_d_conv - 1) * cfg.recurrent_conv_channels();
             let s_elems = cfg.recurrent_state_elems();
@@ -694,7 +835,7 @@ impl SeamKv {
                 be.upload(state.as_ref(), &zeros)
                     .map_err(|e| anyhow!("{e}"))?;
             }
-            if cfg.qwen4exp {
+            if cfg.qwen4exp && !self.segmented_kv.enabled {
                 for cache in self.qsa_kbufs.iter().chain(&self.qsa_cbufs).flatten() {
                     let zeros = vec![0u8; cache.len_bytes()];
                     be.upload(cache.as_ref(), &zeros)
@@ -863,6 +1004,10 @@ impl SeamKv {
         let mut vbufs: Vec<Box<dyn Buffer>> = Vec::new();
         let mut qsa_kbufs: Vec<Option<Box<dyn Buffer>>> = Vec::new();
         let mut qsa_cbufs: Vec<Option<Box<dyn Buffer>>> = Vec::new();
+        let segmented_layout = self.segmented_kv.enabled.then(|| {
+            SegmentedKvLayout::for_qwen(cfg, self.max_ctx, self.k_fmt, self.v_fmt)
+                .expect("a segmented Qwen slot keeps its Qwen geometry when forked")
+        });
         for l in 0..cfg.n_layer {
             let (k_bytes, v_bytes) = crate::seam::layer_state_bytes(
                 cfg,
@@ -874,28 +1019,46 @@ impl SeamKv {
                 self.v_fmt,
             );
             kbufs.push(
-                be.alloc(k_bytes, BufferUsage::KvCache)
-                    .map_err(|e| anyhow!("{e}"))?,
+                if let Some(layout) = segmented_layout
+                    .as_ref()
+                    .filter(|layout| layout.plane(l, PlaneKind::K).is_some())
+                {
+                    alloc_segmented_plane(be, layout, l, PlaneKind::K)?
+                } else {
+                    be.alloc(k_bytes, BufferUsage::KvCache)
+                        .map_err(|e| anyhow!("{e}"))?
+                },
             );
             vbufs.push(
-                be.alloc(v_bytes, BufferUsage::KvCache)
-                    .map_err(|e| anyhow!("{e}"))?,
+                if let Some(layout) = segmented_layout
+                    .as_ref()
+                    .filter(|layout| layout.plane(l, PlaneKind::V).is_some())
+                {
+                    alloc_segmented_plane(be, layout, l, PlaneKind::V)?
+                } else {
+                    be.alloc(v_bytes, BufferUsage::KvCache)
+                        .map_err(|e| anyhow!("{e}"))?
+                },
             );
             let qsa_bytes = crate::seam::qsa_raw_cache_bytes(cfg, l, self.max_ctx);
             qsa_kbufs.push(if qsa_bytes > 0 {
-                Some(
+                Some(if let Some(layout) = segmented_layout.as_ref() {
+                    alloc_segmented_plane(be, layout, l, PlaneKind::QsaRaw)?
+                } else {
                     be.alloc(qsa_bytes, BufferUsage::KvCache)
-                        .map_err(|e| anyhow!("{e}"))?,
-                )
+                        .map_err(|e| anyhow!("{e}"))?
+                })
             } else {
                 None
             });
             let qsa_comp_bytes = crate::seam::qsa_block_cache_bytes(cfg, l, self.max_ctx);
             qsa_cbufs.push(if qsa_comp_bytes > 0 {
-                Some(
+                Some(if let Some(layout) = segmented_layout.as_ref() {
+                    alloc_segmented_plane(be, layout, l, PlaneKind::QsaBlock)?
+                } else {
                     be.alloc(qsa_comp_bytes, BufferUsage::KvCache)
-                        .map_err(|e| anyhow!("{e}"))?,
-                )
+                        .map_err(|e| anyhow!("{e}"))?
+                })
             } else {
                 None
             });
@@ -947,6 +1110,11 @@ impl SeamKv {
             vbufs,
             qsa_kbufs,
             qsa_cbufs,
+            segmented_kv: if self.segmented_kv.enabled {
+                SegmentedKvState::enabled()
+            } else {
+                SegmentedKvState::default()
+            },
             k_fmt: self.k_fmt,
             v_fmt: self.v_fmt,
             hidden_buf: be

--- a/crates/infr-vulkan/build.rs
+++ b/crates/infr-vulkan/build.rs
@@ -123,6 +123,33 @@ fn main() {
             "attn_partial_mrows_c256_bda",
             &["-DSC_MAX=256u", "-DKV_BDA"],
         ),
+        // Lazily committed 32K-row KV segments. Bindings 1/2 carry address tables while the
+        // physical segments retain the existing local f16 or planar-Q8 representation.
+        (
+            "attn_partial",
+            "attn_partial_seg",
+            &["-DKV_BDA", "-DKV_SEGMENTED"],
+        ),
+        (
+            "attn_partial",
+            "attn_partial_seg_nohd",
+            &["-DKV_BDA", "-DKV_SEGMENTED", "-DNO_HD_SPEC"],
+        ),
+        (
+            "attn_partial",
+            "attn_partial_seg_kq8",
+            &["-DKV_BDA", "-DKV_SEGMENTED", "-DKQ8"],
+        ),
+        (
+            "attn_partial",
+            "attn_partial_seg_vq8",
+            &["-DKV_BDA", "-DKV_SEGMENTED", "-DVQ8"],
+        ),
+        (
+            "attn_partial",
+            "attn_partial_seg_q8",
+            &["-DKV_BDA", "-DKV_SEGMENTED", "-DKQ8", "-DVQ8"],
+        ),
         // PROBE (B7 slice 1, tests/attn_ktile_probe.rs only — NOTHING in production dispatches
         // these): LDS-staged K-tile flash-decoding pass 1, one whole 128-dim dot per THREAD out of
         // shared memory, so attn_partial's per-key `subgroupAdd` disappears. Four configurations:
@@ -768,8 +795,15 @@ fn main() {
         ("store_q8", "store_q8", &[]),
         ("store_q8", "store_q8_dyn", &["-DUSE_PARAMS"]),
         ("store_q8", "store_q8_f16", &["-DSRC_F16"]),
+        ("store_q8", "store_q8_seg", &["-DKV_SEGMENTED"]),
+        (
+            "store_q8",
+            "store_q8_f16_seg",
+            &["-DSRC_F16", "-DKV_SEGMENTED"],
+        ),
         // Expand a Q8_0 KV prefix → f16 scratch so the f16 flash/non-FA prefill kernels can run.
         ("dequant_q8_f16", "dequant_q8_f16", &[]),
+        ("dequant_q8_f16", "dequant_q8_f16_seg", &["-DKV_SEGMENTED"]),
         (
             "store_q8",
             "store_q8_f16_dyn",
@@ -985,6 +1019,16 @@ fn main() {
         ("store_f16", "store_f16_bda", &["-DKV_BDA"]),
         (
             "store_f16",
+            "store_f16_seg",
+            &["-DKV_BDA", "-DKV_SEGMENTED"],
+        ),
+        (
+            "store_f16",
+            "store_f16_f16_seg",
+            &["-DSRC_F16", "-DKV_BDA", "-DKV_SEGMENTED"],
+        ),
+        (
+            "store_f16",
             "store_f16_dyn_bda",
             &["-DUSE_PARAMS", "-DKV_BDA"],
         ),
@@ -995,6 +1039,11 @@ fn main() {
             &["-DOUT_F16", "-DUSE_PARAMS", "-DKV_BDA"],
         ),
         ("qk_norm_rope", "qk_norm_rope_bda", &["-DKV_BDA"]),
+        (
+            "qk_norm_rope",
+            "qk_norm_rope_seg",
+            &["-DKV_BDA", "-DKV_SEGMENTED"],
+        ),
         (
             "qk_norm_rope",
             "qk_norm_rope_dyn_bda",
@@ -1014,6 +1063,11 @@ fn main() {
             "qk_norm_rope_interleaved",
             "qk_norm_rope_interleaved_bda",
             &["-DKV_BDA"],
+        ),
+        (
+            "qk_norm_rope_interleaved",
+            "qk_norm_rope_interleaved_seg",
+            &["-DKV_BDA", "-DKV_SEGMENTED"],
         ),
         (
             "qk_norm_rope_interleaved",

--- a/crates/infr-vulkan/build.rs
+++ b/crates/infr-vulkan/build.rs
@@ -720,11 +720,26 @@ fn main() {
         ("dsv4_indexer_topk", "dsv4_indexer_topk", &[]),
         ("dsv4_gather", "dsv4_gather", &[]),
         ("qsa_indexer_compress", "qsa_indexer_compress", &[]),
+        (
+            "qsa_indexer_compress",
+            "qsa_indexer_compress_seg",
+            &["-DKV_SEGMENTED"],
+        ),
         ("qsa_indexer_score", "qsa_indexer_score", &[]),
+        (
+            "qsa_indexer_score",
+            "qsa_indexer_score_seg",
+            &["-DKV_SEGMENTED"],
+        ),
         (
             "qsa_indexer_score",
             "qsa_indexer_score_decode8",
             &["-DQSA_SCORE_DECODE8"],
+        ),
+        (
+            "qsa_indexer_score",
+            "qsa_indexer_score_decode8_seg",
+            &["-DQSA_SCORE_DECODE8", "-DKV_SEGMENTED"],
         ),
         ("qsa_indexer_topk", "qsa_indexer_topk", &[]),
         ("qsa_indexer_topk_hist", "qsa_indexer_topk_hist", &[]),
@@ -734,6 +749,22 @@ fn main() {
         ("qsa_gather", "qsa_gather_kq8", &["-DKQ8"]),
         ("qsa_gather", "qsa_gather_vq8", &["-DVQ8"]),
         ("qsa_gather", "qsa_gather_q8", &["-DKQ8", "-DVQ8"]),
+        ("qsa_gather", "qsa_gather_seg", &["-DKV_SEGMENTED"]),
+        (
+            "qsa_gather",
+            "qsa_gather_kq8_seg",
+            &["-DKQ8", "-DKV_SEGMENTED"],
+        ),
+        (
+            "qsa_gather",
+            "qsa_gather_vq8_seg",
+            &["-DVQ8", "-DKV_SEGMENTED"],
+        ),
+        (
+            "qsa_gather",
+            "qsa_gather_q8_seg",
+            &["-DKQ8", "-DVQ8", "-DKV_SEGMENTED"],
+        ),
         ("qsa_attention_batch", "qsa_attention_batch", &[]),
         ("qsa_attention_batch", "qsa_attention_batch_kq8", &["-DKQ8"]),
         ("qsa_attention_batch", "qsa_attention_batch_vq8", &["-DVQ8"]),
@@ -741,6 +772,26 @@ fn main() {
             "qsa_attention_batch",
             "qsa_attention_batch_q8",
             &["-DKQ8", "-DVQ8"],
+        ),
+        (
+            "qsa_attention_batch",
+            "qsa_attention_batch_seg",
+            &["-DKV_SEGMENTED"],
+        ),
+        (
+            "qsa_attention_batch",
+            "qsa_attention_batch_kq8_seg",
+            &["-DKQ8", "-DKV_SEGMENTED"],
+        ),
+        (
+            "qsa_attention_batch",
+            "qsa_attention_batch_vq8_seg",
+            &["-DVQ8", "-DKV_SEGMENTED"],
+        ),
+        (
+            "qsa_attention_batch",
+            "qsa_attention_batch_q8_seg",
+            &["-DKQ8", "-DVQ8", "-DKV_SEGMENTED"],
         ),
         // DeepSeek V4 Sinkhorn hyper-connections (Op::HyperConnectMix / Pre / Post). `-DGATES`
         // adds the `post` + `comb` outputs; without it the mix kernel is `build_hc_head`'s

--- a/crates/infr-vulkan/shaders/attn_partial.comp
+++ b/crates/infr-vulkan/shaders/attn_partial.comp
@@ -121,6 +121,12 @@ vec4 dqv4(uint g) {
 #endif
 #endif
 layout(binding = 0) readonly buffer QB { f16vec4 q4[]; };    // [rows, nh, hd] as vec4
+#ifdef KV_SEGMENTED
+// The ordinary cache bindings become address tables. Each physical 32K-row segment keeps the
+// original local f16 or planar-Q8 layout, so only the address calculation changes below.
+layout(binding = 1) readonly buffer KB { uvec2 k_segments[]; };
+layout(binding = 2) readonly buffer VB { uvec2 v_segments[]; };
+#endif
 // PLANAR Q8_0 KV cache (per-side): codes int8[cap] then scales f16[cap/32] (see store_q8), read as
 // `uint` words — each `f16vec4` load becomes ONE aligned u32 (4 codes) + one scale word shared by the
 // 8 vec4s of a block. K and V pick their dtype INDEPENDENTLY (-DKQ8 / -DVQ8), so the four f16/q8
@@ -134,7 +140,20 @@ layout(binding = 0) readonly buffer QB { f16vec4 q4[]; };    // [rows, nh, hd] a
 vec4 kvec4_ml(uint i4) { return dqv4(i4 << 2u); }
 #define KVEC4(i) kvec4_ml(i)
 #elif defined(KQ8)
-#ifdef KV_BDA
+#ifdef KV_SEGMENTED
+vec4 kvec4(uint i4) {
+    uint elem = i4 << 2u;
+    uint local = kv_segment_local(elem, pc.cap);
+    uint64_t base = kv_segment_base(k_segments[kv_segment(elem, pc.cap)]);
+    int cw = int(kv_word(base, local >> 2u));
+    uint bk = local >> 5u;
+    uint seg_elems = 1u << pc.cap;
+    float d = unpackHalf2x16(kv_word(base, (seg_elems >> 2u) + (bk >> 1u)))[bk & 1u];
+    return d * vec4(bitfieldExtract(cw, 0, 8), bitfieldExtract(cw, 8, 8),
+                    bitfieldExtract(cw, 16, 8), bitfieldExtract(cw, 24, 8));
+}
+#define KVEC4(i) kvec4(i)
+#elif defined(KV_BDA)
 // Planar-Q8 K by device address: the code word (`ku[i4]`) and the block scale are single u32 words,
 // so each reads through kv_word (one global_load_b32) off k_addr — the wide KV2/KV4 reads are for the
 // f16 vec4 loads below, not the already-scalar Q8 words. Mirrors attention_kv.comp's -DKV_BDA dq8k.
@@ -158,7 +177,16 @@ vec4 kvec4(uint i4) {
 #define KVEC4(i) kvec4(i)
 #endif
 #else
-#ifdef KV_BDA
+#ifdef KV_SEGMENTED
+vec4 kread4(uint i4) {
+    uint elem = i4 << 2u;
+    uint local = kv_segment_local(elem, pc.cap);
+    uint64_t base = kv_segment_base(k_segments[kv_segment(elem, pc.cap)]);
+    uvec2 w = KV2(base, local >> 1u);
+    return vec4(unpackHalf2x16(w.x), unpackHalf2x16(w.y));
+}
+#define KVEC4(i) kread4(i)
+#elif defined(KV_BDA)
 // f16 K by device address: one `f16vec4` (8 bytes) = two adjacent u32 words = ONE KV2 read (a single
 // global_load_b64 with a saddr scalar base), NOT four kv_half calls (four unfused global_load_b16 —
 // the bandwidth regression this whole slice exists to avoid). Word base = vec4-index << 1; the two
@@ -179,7 +207,20 @@ layout(binding = 1) readonly buffer KB { f16vec4 k4[]; };    // cache [kv_len, n
 vec4 vvec4_ml(uint i4) { return dqv4(i4 << 2u); }
 #define VVEC4(i) vvec4_ml(i)
 #elif defined(VQ8)
-#ifdef KV_BDA
+#ifdef KV_SEGMENTED
+vec4 vvec4(uint i4) {
+    uint elem = i4 << 2u;
+    uint local = kv_segment_local(elem, pc.cap);
+    uint64_t base = kv_segment_base(v_segments[kv_segment(elem, pc.cap)]);
+    int cw = int(kv_word(base, local >> 2u));
+    uint bk = local >> 5u;
+    uint seg_elems = 1u << pc.cap;
+    float d = unpackHalf2x16(kv_word(base, (seg_elems >> 2u) + (bk >> 1u)))[bk & 1u];
+    return d * vec4(bitfieldExtract(cw, 0, 8), bitfieldExtract(cw, 8, 8),
+                    bitfieldExtract(cw, 16, 8), bitfieldExtract(cw, 24, 8));
+}
+#define VVEC4(i) vvec4(i)
+#elif defined(KV_BDA)
 vec4 vvec4(uint i4) {
     int cw = int(kv_word(v_addr, i4));
     uint bk = i4 >> 3u;
@@ -200,7 +241,16 @@ vec4 vvec4(uint i4) {
 #define VVEC4(i) vvec4(i)
 #endif
 #else
-#ifdef KV_BDA
+#ifdef KV_SEGMENTED
+vec4 vread4(uint i4) {
+    uint elem = i4 << 2u;
+    uint local = kv_segment_local(elem, pc.cap);
+    uint64_t base = kv_segment_base(v_segments[kv_segment(elem, pc.cap)]);
+    uvec2 w = KV2(base, local >> 1u);
+    return vec4(unpackHalf2x16(w.x), unpackHalf2x16(w.y));
+}
+#define VVEC4(i) vread4(i)
+#elif defined(KV_BDA)
 // f16 V by device address — same KV2 b64 read shape as f16 K above, off v_addr.
 vec4 vread4(uint i4) {
     uvec2 w = KV2(v_addr, i4 << 1u);
@@ -231,7 +281,7 @@ shared vec4 vsh[32];   // one subgroup's V partial, summed into the other (full-
 
 void main() {
     uint t = gl_LocalInvocationIndex;
-#ifdef KV_BDA
+#if defined(KV_BDA) && !defined(KV_SEGMENTED)
     // Wave-uniform K/V cache base pointers, set ONCE (kv_addr.glsl). Every KVEC4/VVEC4 adds a u32
     // element/word offset to these before the uint64_t cast → saddr scalar-base loads (no per-load
     // 64-bit carry-add) and, for f16, a fused b64.
@@ -325,8 +375,12 @@ void main() {
     // Key/value POSITION j lives at row j % rcap — the ring only ever recycles rows whose
     // positions the sliding-window mask (lo/j0) already excludes, so this mapping is exact. On a
     // full-context cache every processed j < kv_len <= rcap, so RROW is an identity there.
+#ifdef KV_SEGMENTED
+#define RROW(j) (j)
+#else
     uint rcap = (pc.cap > 0u) ? pc.cap / (pc.nkv * hd) : 0u;
 #define RROW(j) ((rcap > 0u) ? ((j) % rcap) : (j))
+#endif
     // QK via subgroup reduction (one key per subgroup-iteration; vec4 coalesced K reads). Each lane's
     // query vec4(s) are loop-invariant across keys → hold in registers (no q_sh, no barrier).
     uint sg = gl_SubgroupID;            // 0..1

--- a/crates/infr-vulkan/shaders/dequant_q8_f16.comp
+++ b/crates/infr-vulkan/shaders/dequant_q8_f16.comp
@@ -14,17 +14,32 @@ layout(local_size_x = 64, local_size_y = 1, local_size_z = 1) in;
 layout(push_constant) uniform PC { uint n; uint cap;
     uint s_lo; uint s_hi;
 } pc;
+#ifdef KV_SEGMENTED
+layout(binding = 0) readonly buffer SB { uvec2 segments[]; };
+#endif
 layout(binding = 1) writeonly buffer DB { float16_t dst[]; };
 #include "kv_addr.glsl"
 #define SU(wi) kv_word(k_addr, (wi))
 
 void main() {
+#ifndef KV_SEGMENTED
     k_addr = kv_base(pc.s_lo, pc.s_hi);
+#endif
     uint i = gl_GlobalInvocationID.x;
     if (i >= pc.n) { return; }
+#ifdef KV_SEGMENTED
+    uint local = kv_segment_local(i, pc.cap);
+    k_addr = kv_segment_base(segments[kv_segment(i, pc.cap)]);
+    uint seg_elems = 1u << pc.cap;
+    int cw = int(SU(local >> 2u));
+    int c = bitfieldExtract(cw, int((local & 3u) * 8u), 8);
+    uint bk = local >> 5u;
+    float d = unpackHalf2x16(SU((seg_elems >> 2u) + (bk >> 1u)))[bk & 1u];
+#else
     int cw = int(SU(i >> 2u));
     int c = bitfieldExtract(cw, int((i & 3u) * 8u), 8);
     uint bk = i >> 5u;
     float d = unpackHalf2x16(SU((pc.cap >> 2u) + (bk >> 1u)))[bk & 1u];
+#endif
     dst[i] = float16_t(d * float(c));
 }

--- a/crates/infr-vulkan/shaders/kv_addr.glsl
+++ b/crates/infr-vulkan/shaders/kv_addr.glsl
@@ -50,6 +50,11 @@ float kv_half(uint64_t base, uint i) {
     return float(KvHalf(base + uint64_t(i << 1u)).v[0]);
 }
 
+layout(buffer_reference, std430, buffer_reference_align = 4) readonly buffer KvF32 { float v[]; };
+float kv_f32(uint64_t base, uint i) {
+    return KvF32(base + uint64_t(i << 2u)).v[0];
+}
+
 // ── Cooperative-matrix tensor base (coopmat flash prefill, #74 slice 4 resurrection) ────────────
 // The coopmat flash-prefill QK/PV `coopMatLoad` reads the KV tensor straight from a buffer_reference
 // base: `coopMatLoad(M, KvMat(k_addr).v, elem_off, stride, layout)`. The pointer carries ONLY the

--- a/crates/infr-vulkan/shaders/kv_addr.glsl
+++ b/crates/infr-vulkan/shaders/kv_addr.glsl
@@ -32,6 +32,16 @@ uint64_t v_addr = 0ul; // V cache base byte address (set once in main from v_lo/
 
 uint64_t kv_base(uint lo, uint hi) { return (uint64_t(hi) << 32) | uint64_t(lo); }
 
+#ifdef KV_SEGMENTED
+// A segmented cache binds a tiny uvec2 address table in the descriptor slot formerly occupied by
+// the flat cache. `shift` is log2(logical elements per segment), so lookup is two integer ops and
+// one uniform table load; the physical segment itself is still read through the established BDA
+// helpers below. Qwen's 32K-row geometry guarantees a power-of-two element count per segment.
+uint kv_segment(uint elem, uint shift) { return elem >> shift; }
+uint kv_segment_local(uint elem, uint shift) { return elem & ((1u << shift) - 1u); }
+uint64_t kv_segment_base(uvec2 address) { return kv_base(address.x, address.y); }
+#endif
+
 // ── Scalar reads (used by attention_kv this slice) ─────────────────────────────────────────────
 // One f16 element `i` off `base` (the f16 KV cache read: `float(k[i])` / `float(v[i])`). Byte
 // offset `i<<1` is built in u32 and added before the cast; deref index is the constant 0 → saddr.

--- a/crates/infr-vulkan/shaders/qk_norm_rope.comp
+++ b/crates/infr-vulkan/shaders/qk_norm_rope.comp
@@ -32,9 +32,13 @@ layout(binding = 1) readonly buffer NB { float nw[]; };
 layout(binding = 2) readonly buffer PB { uint p_pos; uint p_kvlen; };
 #ifdef FREQ_FACTORS
 layout(binding = 3) readonly buffer FF { float ff[]; };
-#ifndef KV_BDA
+#ifdef KV_SEGMENTED
+layout(binding = 4) readonly buffer YB { uvec2 segments[]; };
+#elif !defined(KV_BDA)
 layout(binding = 4) buffer YB { float16_t y[]; };
 #endif
+#elif defined(KV_SEGMENTED)
+layout(binding = 3) readonly buffer YB { uvec2 segments[]; };
 #elif !defined(KV_BDA)
 layout(binding = 3) buffer YB { float16_t y[]; };
 #endif
@@ -42,15 +46,28 @@ layout(binding = 3) buffer YB { float16_t y[]; };
 // gemma4 full-attention layers use proportional RoPE: per-pair frequency divisors (most are huge →
 // those dims are left unrotated). `ff` takes binding 2 (read), `y` shifts to binding 3 (write).
 layout(binding = 2) readonly buffer FF { float ff[]; };
-#ifndef KV_BDA
+#ifdef KV_SEGMENTED
+layout(binding = 3) readonly buffer YB { uvec2 segments[]; };
+#elif !defined(KV_BDA)
 layout(binding = 3) buffer YB { float16_t y[]; };
 #endif
+#elif defined(KV_SEGMENTED)
+layout(binding = 2) readonly buffer YB { uvec2 segments[]; };
 #elif !defined(KV_BDA)
 layout(binding = 2) buffer YB { float16_t y[]; };
 #endif
 #ifdef KV_BDA
 #include "kv_addr.glsl"
+#ifdef KV_SEGMENTED
+void kvw(uint idx, float val) {
+    uint shift = uint(findMSB((pc.nheads * pc.hd) << 15u));
+    uint seg = kv_segment(idx, shift);
+    kv_store_half(kv_segment_base(segments[seg]), kv_segment_local(idx, shift), val);
+}
+#define KVW(idx, val) kvw((idx), (val))
+#else
 #define KVW(idx, val) kv_store_half(k_addr, (idx), (val))
+#endif
 #else
 #define KVW(idx, val) y[idx] = float16_t(val)
 #endif
@@ -59,7 +76,7 @@ shared float xs[512]; // hd up to 512 (gemma4 full layers); 64 threads each hand
 shared float red[64];
 
 void main() {
-#ifdef KV_BDA
+#if defined(KV_BDA) && !defined(KV_SEGMENTED)
     k_addr = kv_base(pc.d_lo, pc.d_hi);
 #endif
     uint t = gl_LocalInvocationID.x;

--- a/crates/infr-vulkan/shaders/qk_norm_rope_interleaved.comp
+++ b/crates/infr-vulkan/shaders/qk_norm_rope_interleaved.comp
@@ -23,23 +23,40 @@ layout(binding = 1) readonly buffer NB { float nw[]; };
 layout(binding = 2) readonly buffer PB { uint p_pos; uint p_kvlen; };
 #ifdef FREQ_FACTORS
 layout(binding = 3) readonly buffer FF { float ff[]; };
-#ifndef KV_BDA
+#ifdef KV_SEGMENTED
+layout(binding = 4) readonly buffer YB { uvec2 segments[]; };
+#elif !defined(KV_BDA)
 layout(binding = 4) buffer YB { float16_t y[]; };
 #endif
+#elif defined(KV_SEGMENTED)
+layout(binding = 3) readonly buffer YB { uvec2 segments[]; };
 #elif !defined(KV_BDA)
 layout(binding = 3) buffer YB { float16_t y[]; };
 #endif
 #elif defined(FREQ_FACTORS)
 layout(binding = 2) readonly buffer FF { float ff[]; };
-#ifndef KV_BDA
+#ifdef KV_SEGMENTED
+layout(binding = 3) readonly buffer YB { uvec2 segments[]; };
+#elif !defined(KV_BDA)
 layout(binding = 3) buffer YB { float16_t y[]; };
 #endif
+#elif defined(KV_SEGMENTED)
+layout(binding = 2) readonly buffer YB { uvec2 segments[]; };
 #elif !defined(KV_BDA)
 layout(binding = 2) buffer YB { float16_t y[]; };
 #endif
 #ifdef KV_BDA
 #include "kv_addr.glsl"
+#ifdef KV_SEGMENTED
+void kvw(uint idx, float val) {
+    uint shift = uint(findMSB((pc.nheads * pc.hd) << 15u));
+    uint seg = kv_segment(idx, shift);
+    kv_store_half(kv_segment_base(segments[seg]), kv_segment_local(idx, shift), val);
+}
+#define KVW(idx, val) kvw((idx), (val))
+#else
 #define KVW(idx, val) kv_store_half(k_addr, (idx), (val))
+#endif
 #else
 #define KVW(idx, val) y[idx] = float16_t(val)
 #endif
@@ -48,7 +65,7 @@ shared float xs[512];
 shared float red[64];
 
 void main() {
-#ifdef KV_BDA
+#if defined(KV_BDA) && !defined(KV_SEGMENTED)
     k_addr = kv_base(pc.d_lo, pc.d_hi);
 #endif
     uint t = gl_LocalInvocationID.x;

--- a/crates/infr-vulkan/shaders/qsa_attention_batch.comp
+++ b/crates/infr-vulkan/shaders/qsa_attention_batch.comp
@@ -1,4 +1,9 @@
 #version 460
+#ifdef KV_SEGMENTED
+#extension GL_EXT_buffer_reference2 : require
+#extension GL_EXT_shader_explicit_arithmetic_types_int64 : require
+#extension GL_EXT_shader_explicit_arithmetic_types_float16 : require
+#endif
 // Correctness-first batched Qwen3.8 QSA attention. One workgroup owns one (query row, attention
 // head), reads that row's selected complete blocks directly from F16 or planar-Q8 KV caches,
 // appends its incomplete causal tail, and performs an exact two-pass softmax. Each lane owns one
@@ -16,10 +21,17 @@ layout(push_constant) uniform PC {
     float scale;
     uint kcap;
     uint vcap;
+    uint segment_shift;
 } pc;
 layout(binding = 0) readonly buffer QB { uint q[]; };
+#ifdef KV_SEGMENTED
+layout(binding = 1) readonly buffer KB { uvec2 k_segments[]; };
+layout(binding = 2) readonly buffer VB { uvec2 v_segments[]; };
+#include "kv_addr.glsl"
+#else
 layout(binding = 1) readonly buffer KB { uint k[]; };
 layout(binding = 2) readonly buffer VB { uint v[]; };
+#endif
 layout(binding = 3) readonly buffer IB { uint indices[]; };
 layout(binding = 4) writeonly buffer DB { float dst[]; };
 
@@ -35,6 +47,22 @@ float qread(uint i) {
 }
 
 float kread(uint i) {
+#ifdef KV_SEGMENTED
+    uint local = kv_segment_local(i, pc.segment_shift);
+    uint64_t base = kv_segment_base(k_segments[kv_segment(i, pc.segment_shift)]);
+#ifdef KQ8
+    int codes = int(kv_word(base, local >> 2u));
+    int code = bitfieldExtract(codes, int((local & 3u) * 8u), 8);
+    uint block = local >> 5u;
+    uint segment_elems = 1u << pc.segment_shift;
+    float scale = unpackHalf2x16(
+        kv_word(base, (segment_elems >> 2u) + (block >> 1u))
+    )[block & 1u];
+    return scale * float(code);
+#else
+    return kv_half(base, local);
+#endif
+#else
 #ifdef KQ8
     int codes = int(k[i >> 2u]);
     int code = bitfieldExtract(codes, int((i & 3u) * 8u), 8);
@@ -46,9 +74,26 @@ float kread(uint i) {
     uint h = (i & 1u) == 0u ? w & 0xffffu : w >> 16u;
     return unpackHalf2x16(h).x;
 #endif
+#endif
 }
 
 float vread(uint i) {
+#ifdef KV_SEGMENTED
+    uint local = kv_segment_local(i, pc.segment_shift);
+    uint64_t base = kv_segment_base(v_segments[kv_segment(i, pc.segment_shift)]);
+#ifdef VQ8
+    int codes = int(kv_word(base, local >> 2u));
+    int code = bitfieldExtract(codes, int((local & 3u) * 8u), 8);
+    uint block = local >> 5u;
+    uint segment_elems = 1u << pc.segment_shift;
+    float scale = unpackHalf2x16(
+        kv_word(base, (segment_elems >> 2u) + (block >> 1u))
+    )[block & 1u];
+    return scale * float(code);
+#else
+    return kv_half(base, local);
+#endif
+#else
 #ifdef VQ8
     int codes = int(v[i >> 2u]);
     int code = bitfieldExtract(codes, int((i & 3u) * 8u), 8);
@@ -59,6 +104,7 @@ float vread(uint i) {
     uint w = v[i >> 1u];
     uint h = (i & 1u) == 0u ? w & 0xffffu : w >> 16u;
     return unpackHalf2x16(h).x;
+#endif
 #endif
 }
 

--- a/crates/infr-vulkan/shaders/qsa_gather.comp
+++ b/crates/infr-vulkan/shaders/qsa_gather.comp
@@ -1,4 +1,9 @@
 #version 460
+#ifdef KV_SEGMENTED
+#extension GL_EXT_buffer_reference2 : require
+#extension GL_EXT_shader_explicit_arithmetic_types_int64 : require
+#extension GL_EXT_shader_explicit_arithmetic_types_float16 : require
+#endif
 // Gather selected complete QSA blocks and the incomplete causal tail into packed-F16 scratch.
 // KQ8/VQ8 read infr's planar KV layout: int8 codes in [0, cap), then one f16 scale per 32 codes.
 layout(local_size_x = 256, local_size_y = 1, local_size_z = 1) in;
@@ -12,30 +17,71 @@ layout(push_constant) uniform PC {
     uint total_pairs;
     uint kcap;
     uint vcap;
+    uint segment_shift;
 } pc;
+#ifdef KV_SEGMENTED
+layout(binding = 0) readonly buffer KB { uvec2 k_segments[]; };
+layout(binding = 1) readonly buffer VB { uvec2 v_segments[]; };
+#include "kv_addr.glsl"
+#else
 layout(binding = 0) readonly buffer KB { uint k[]; };
 layout(binding = 1) readonly buffer VB { uint v[]; };
+#endif
 layout(binding = 2) readonly buffer IB { uint indices[]; };
 layout(binding = 3) writeonly buffer KDB { uint kd[]; };
 layout(binding = 4) writeonly buffer VDB { uint vd[]; };
 
-#ifdef KQ8
+#if defined(KQ8) || defined(KV_SEGMENTED)
 float kread(uint i) {
+#ifdef KV_SEGMENTED
+    uint local = kv_segment_local(i, pc.segment_shift);
+    uint64_t base = kv_segment_base(k_segments[kv_segment(i, pc.segment_shift)]);
+#ifdef KQ8
+    int codes = int(kv_word(base, local >> 2u));
+    int code = bitfieldExtract(codes, int((local & 3u) * 8u), 8);
+    uint block = local >> 5u;
+    uint segment_elems = 1u << pc.segment_shift;
+    float scale = unpackHalf2x16(
+        kv_word(base, (segment_elems >> 2u) + (block >> 1u))
+    )[block & 1u];
+    return scale * float(code);
+#else
+    return kv_half(base, local);
+#endif
+#else
     int codes = int(k[i >> 2u]);
     int code = bitfieldExtract(codes, int((i & 3u) * 8u), 8);
     uint block = i >> 5u;
     float scale = unpackHalf2x16(k[(pc.kcap >> 2u) + (block >> 1u)])[block & 1u];
     return scale * float(code);
+#endif
 }
 #endif
 
-#ifdef VQ8
+#if defined(VQ8) || defined(KV_SEGMENTED)
 float vread(uint i) {
+#ifdef KV_SEGMENTED
+    uint local = kv_segment_local(i, pc.segment_shift);
+    uint64_t base = kv_segment_base(v_segments[kv_segment(i, pc.segment_shift)]);
+#ifdef VQ8
+    int codes = int(kv_word(base, local >> 2u));
+    int code = bitfieldExtract(codes, int((local & 3u) * 8u), 8);
+    uint block = local >> 5u;
+    uint segment_elems = 1u << pc.segment_shift;
+    float scale = unpackHalf2x16(
+        kv_word(base, (segment_elems >> 2u) + (block >> 1u))
+    )[block & 1u];
+    return scale * float(code);
+#else
+    return kv_half(base, local);
+#endif
+#else
     int codes = int(v[i >> 2u]);
     int code = bitfieldExtract(codes, int((i & 3u) * 8u), 8);
     uint block = i >> 5u;
     float scale = unpackHalf2x16(v[(pc.vcap >> 2u) + (block >> 1u)])[block & 1u];
     return scale * float(code);
+#endif
 }
 #endif
 
@@ -53,13 +99,13 @@ void main() {
         src_row = pc.complete * pc.ratio + out_row - selected_rows;
     }
     uint src_pair = src_row * pc.row_pairs + in_row;
-#ifdef KQ8
+#if defined(KQ8) || defined(KV_SEGMENTED)
     uint ke = src_pair * 2u;
     kd[pair] = packHalf2x16(vec2(kread(ke), kread(ke + 1u)));
 #else
     kd[pair] = k[src_pair];
 #endif
-#ifdef VQ8
+#if defined(VQ8) || defined(KV_SEGMENTED)
     uint ve = src_pair * 2u;
     vd[pair] = packHalf2x16(vec2(vread(ve), vread(ve + 1u)));
 #else

--- a/crates/infr-vulkan/shaders/qsa_indexer_compress.comp
+++ b/crates/infr-vulkan/shaders/qsa_indexer_compress.comp
@@ -1,4 +1,9 @@
 #version 460
+#ifdef KV_SEGMENTED
+#extension GL_EXT_buffer_reference2 : require
+#extension GL_EXT_shader_explicit_arithmetic_types_int64 : require
+#extension GL_EXT_shader_explicit_arithmetic_types_float16 : require
+#endif
 // Materialize each newly-complete QSA block once. This is bit-for-bit the old score shader's
 // key path: mean in f32, round to f16, RMSNorm, then RoPE at the block's first token position.
 layout(local_size_x = 128, local_size_y = 1, local_size_z = 1) in;
@@ -11,18 +16,35 @@ layout(push_constant) uniform PC {
     uint rope_dim;
     float theta;
     float eps;
+    uint raw_shift;
+    uint block_shift;
 } pc;
+#ifdef KV_SEGMENTED
+layout(binding = 0) readonly buffer KB { uvec2 raw_segments[]; };
+#else
 layout(binding = 0) readonly buffer KB { uint raw_k[]; };
+#endif
 layout(binding = 1) readonly buffer NB { float norm[]; };
+#ifdef KV_SEGMENTED
+layout(binding = 2) readonly buffer CB { uvec2 block_segments[]; };
+#include "kv_addr.glsl"
+#else
 layout(binding = 2) writeonly buffer CB { float block_k[]; };
+#endif
 
 shared float keyv[128];
 shared float rmsv[128];
 
 float kread(uint i) {
+#ifdef KV_SEGMENTED
+    uint local = kv_segment_local(i, pc.raw_shift);
+    uint64_t base = kv_segment_base(raw_segments[kv_segment(i, pc.raw_shift)]);
+    return kv_half(base, local);
+#else
     uint w = raw_k[i >> 1u];
     uint h = (i & 1u) == 0u ? w & 0xffffu : w >> 16u;
     return unpackHalf2x16(h).x;
+#endif
 }
 
 void main() {
@@ -59,5 +81,12 @@ void main() {
         float b = keyv[base + 1u];
         kn = (d & 1u) == 0u ? a * c - b * s : a * s + b * c;
     }
-    block_k[block * pc.head_dim + d] = kn;
+    uint out_elem = block * pc.head_dim + d;
+#ifdef KV_SEGMENTED
+    uint local = kv_segment_local(out_elem, pc.block_shift);
+    uint64_t base = kv_segment_base(block_segments[kv_segment(out_elem, pc.block_shift)]);
+    kv_store_f32(base, local, kn);
+#else
+    block_k[out_elem] = kn;
+#endif
 }

--- a/crates/infr-vulkan/shaders/qsa_indexer_score.comp
+++ b/crates/infr-vulkan/shaders/qsa_indexer_score.comp
@@ -1,6 +1,11 @@
 #version 460
 #extension GL_KHR_shader_subgroup_basic : require
 #extension GL_KHR_shader_subgroup_arithmetic : require
+#ifdef KV_SEGMENTED
+#extension GL_EXT_buffer_reference2 : require
+#extension GL_EXT_shader_explicit_arithmetic_types_int64 : require
+#extension GL_EXT_shader_explicit_arithmetic_types_float16 : require
+#endif
 // Score a query/block tile. Final block keys are materialized once by qsa_indexer_compress; this
 // kernel only stages reusable Q/K data and computes the positive-head dot sum. A fixed wave32
 // pipeline gives eight subgroups, one per query/block pair. Decode uses 1 query x 8 blocks so no
@@ -14,9 +19,15 @@ layout(push_constant) uniform PC {
     uint head_dim;
     uint ratio;
     float scale;
+    uint block_shift;
 } pc;
 layout(binding = 0) readonly buffer QB { uint q[]; };
+#ifdef KV_SEGMENTED
+layout(binding = 1) readonly buffer KB { uvec2 block_segments[]; };
+#include "kv_addr.glsl"
+#else
 layout(binding = 1) readonly buffer KB { float block_k[]; };
+#endif
 layout(binding = 2) writeonly buffer SB { float scores[]; };
 
 #ifdef QSA_SCORE_DECODE8
@@ -34,6 +45,16 @@ float qread(uint i) {
     uint w = q[i >> 1u];
     uint h = (i & 1u) == 0u ? w & 0xffffu : w >> 16u;
     return unpackHalf2x16(h).x;
+}
+
+float block_read(uint i) {
+#ifdef KV_SEGMENTED
+    uint local = kv_segment_local(i, pc.block_shift);
+    uint64_t base = kv_segment_base(block_segments[kv_segment(i, pc.block_shift)]);
+    return kv_f32(base, local);
+#else
+    return block_k[i];
+#endif
 }
 
 void main() {
@@ -56,7 +77,7 @@ void main() {
         uint bs = i >> 7u;
         uint block = block_base + bs;
         ktile[bs][d] = block < max_blocks
-            ? block_k[block * pc.head_dim + d]
+            ? block_read(block * pc.head_dim + d)
             : 0.0;
     }
     barrier();

--- a/crates/infr-vulkan/shaders/store_f16.comp
+++ b/crates/infr-vulkan/shaders/store_f16.comp
@@ -15,16 +15,24 @@ layout(push_constant) uniform PC { uint n; uint off; uint src_off; uint cap;
     uint d_lo; uint d_hi; // K/V cache dst base device address (uvec2-split)
 #endif
 } pc;
+#ifdef SRC_F16
+layout(binding = 0) readonly buffer SB { float16_t src[]; };
+#else
 layout(binding = 0) readonly buffer SB { float src[]; };
+#endif
 #ifdef USE_PARAMS
 // Record-once decode: the write offset is row*n (one KV row at position pos), pos from a host-updated
 // params SSBO instead of the `pc.off` push constant. `dst` moves to binding 2 (params takes 1).
 // `cap` is the cache's ROW capacity: an SWA ring cache recycles rows the window mask already
 // excludes, so the row is pos % cap (identity on a full-context cache, where pos < cap always).
 layout(binding = 1) readonly buffer PB { uint p_pos; uint p_kvlen; };
-#ifndef KV_BDA
+#ifdef KV_SEGMENTED
+layout(binding = 2) readonly buffer DB { uvec2 segments[]; };
+#elif !defined(KV_BDA)
 layout(binding = 2) buffer DB { float16_t dst[]; };
 #endif
+#elif defined(KV_SEGMENTED)
+layout(binding = 1) readonly buffer DB { uvec2 segments[]; };
 #elif !defined(KV_BDA)
 layout(binding = 1) buffer DB { float16_t dst[]; };
 #endif
@@ -33,7 +41,7 @@ layout(binding = 1) buffer DB { float16_t dst[]; };
 #endif
 
 void main() {
-#ifdef KV_BDA
+#if defined(KV_BDA) && !defined(KV_SEGMENTED)
     k_addr = kv_base(pc.d_lo, pc.d_hi);
 #endif
     uint i = gl_GlobalInvocationID.x;
@@ -44,7 +52,12 @@ void main() {
 #else
     uint off = pc.off;
 #endif
-#ifdef KV_BDA
+#ifdef KV_SEGMENTED
+    uint elem = off + i;
+    uint seg = kv_segment(elem, pc.cap);
+    uint local = kv_segment_local(elem, pc.cap);
+    kv_store_half(kv_segment_base(segments[seg]), local, src[pc.src_off + i]);
+#elif defined(KV_BDA)
     kv_store_half(k_addr, off + i, src[pc.src_off + i]);
 #else
     dst[off + i] = float16_t(src[pc.src_off + i]);

--- a/crates/infr-vulkan/shaders/store_q8.comp
+++ b/crates/infr-vulkan/shaders/store_q8.comp
@@ -31,20 +31,29 @@ layout(binding = 0) readonly buffer SB { float src[]; };
 #endif
 #ifdef USE_PARAMS
 layout(binding = 1) readonly buffer PB { uint p_pos; uint p_kvlen; };
+#ifdef KV_SEGMENTED
+layout(binding = 2) readonly buffer CB { uvec2 segments[]; };
+#endif
+#elif defined(KV_SEGMENTED)
+layout(binding = 1) readonly buffer CB { uvec2 segments[]; };
 #endif
 #define KV_STORE_BYTE
 #include "kv_addr.glsl"
 #define STB(bo, v) kv_store_byte(k_addr, (bo), (v))
 
 void main() {
-    k_addr = kv_base(pc.d_lo, pc.d_hi);
     uint blk = gl_WorkGroupID.x;         // 0 .. n/32-1  (source block)
     uint t = gl_LocalInvocationID.x;     // 0 .. 31      (element within block)
 #ifdef USE_PARAMS
     // SWA ring cache: row capacity = cap/n (total elements / row width; decode writes one row, so
     // n IS the row width here). The ring recycles rows the window mask already excludes, so the
     // write row is pos % rows — an identity on a full-context cache (pos < rows always).
-    uint rows = pc.cap / pc.n;
+    uint rows =
+#ifdef KV_SEGMENTED
+        0u;
+#else
+        pc.cap / pc.n;
+#endif
     uint row = (rows > 0u) ? (p_pos % rows) : p_pos;
     uint off = row * pc.n;
 #else
@@ -57,11 +66,25 @@ void main() {
     int q = clamp(int(round(v * inv)), -127, 127);
     // Planar: code byte = global element index (codes region [0,cap)); scale for this block sits in
     // the scales region at byte cap + block*2 (block = (off+blk*32)/32 = off/32 + blk).
+#ifdef KV_SEGMENTED
+    uint global_elem = off + blk * 32u + t;
+    uint seg = kv_segment(global_elem, pc.cap);
+    uint elem = kv_segment_local(global_elem, pc.cap);
+    uint seg_elems = 1u << pc.cap;
+    k_addr = kv_segment_base(segments[seg]);
+#else
+    k_addr = kv_base(pc.d_lo, pc.d_hi);
     uint elem = off + blk * 32u + t;
+#endif
     STB(elem, uint(q) & 0xFFu);   // two's-complement byte; reader sign-extends
     if (t == 0u) {
+#ifdef KV_SEGMENTED
+        uint block = elem / 32u;
+        uint sb = seg_elems + block * 2u;
+#else
         uint block = off / 32u + blk;
         uint sb = pc.cap + block * 2u;
+#endif
         uint16_t s = float16BitsToUint16(float16_t(d));
         STB(sb, uint(s & uint16_t(0xFFu)));
         STB(sb + 1u, uint(s >> 8));

--- a/crates/infr-vulkan/src/adapter.rs
+++ b/crates/infr-vulkan/src/adapter.rs
@@ -2665,10 +2665,26 @@ fn lower_op(
             } else {
                 None
             };
+            let raw_cache = r(*k_cache)?;
+            let block_cache = r(*block_cache)?;
+            let (raw_binding, block_binding, segment_shifts) = match (
+                segmented_kv_view(raw_cache),
+                segmented_kv_view(block_cache),
+            ) {
+                (Some((raw_table, raw_shift)), Some((block_table, block_shift))) => {
+                    (raw_table, block_table, Some((raw_shift, block_shift)))
+                }
+                (None, None) => (raw_cache, block_cache, None),
+                _ => {
+                    return Err(be(
+                            "vulkan Op::QsaIndexer raw and block caches must both be segmented or both be flat",
+                        ));
+                }
+            };
             rec.qsa_indexer(
                 r(*q)?,
-                r(*k_cache)?,
-                r(*block_cache)?,
+                raw_binding,
+                block_binding,
                 r(*k_norm)?,
                 pool[&sk].as_ref(),
                 topk_work.map(|id| pool[&id].as_ref()),
@@ -2684,6 +2700,7 @@ fn lower_op(
                 *theta,
                 *eps,
                 *scale,
+                segment_shifts,
             );
         }
         Op::QsaGather {
@@ -2718,9 +2735,28 @@ fn lower_op(
                      k_dtype={kdt:?} v_dtype={vdt:?}"
                 )));
             }
+            let k_cache_buf = r(*k_cache)?;
+            let v_cache_buf = r(*v_cache)?;
+            let (k_binding, v_binding, segment_shift) = match (
+                segmented_kv_view(k_cache_buf),
+                segmented_kv_view(v_cache_buf),
+            ) {
+                (Some((k_table, k_shift)), Some((v_table, v_shift))) if k_shift == v_shift => {
+                    (k_table, v_table, Some(k_shift))
+                }
+                (Some(_), Some(_)) => {
+                    return Err(be("vulkan Op::QsaGather K/V segment geometry differs"));
+                }
+                (None, None) => (k_cache_buf, v_cache_buf, None),
+                _ => {
+                    return Err(be(
+                        "vulkan Op::QsaGather K/V caches must both be segmented or both be flat",
+                    ));
+                }
+            };
             rec.qsa_gather(
-                r(*k_cache)?,
-                r(*v_cache)?,
+                k_binding,
+                v_binding,
                 r(*indices)?,
                 r(*k_dst)?,
                 r(*v_dst)?,
@@ -2733,6 +2769,7 @@ fn lower_op(
                 v_q8,
                 graph.desc(*k_cache).numel() as u32,
                 graph.desc(*v_cache).numel() as u32,
+                segment_shift,
             );
         }
         Op::QsaBatchAttention {
@@ -2778,10 +2815,31 @@ fn lower_op(
                      k_dtype={kdt:?} v_dtype={vdt:?}"
                 )));
             }
+            let k_cache_buf = r(*k_cache)?;
+            let v_cache_buf = r(*v_cache)?;
+            let (k_binding, v_binding, segment_shift) = match (
+                segmented_kv_view(k_cache_buf),
+                segmented_kv_view(v_cache_buf),
+            ) {
+                (Some((k_table, k_shift)), Some((v_table, v_shift))) if k_shift == v_shift => {
+                    (k_table, v_table, Some(k_shift))
+                }
+                (Some(_), Some(_)) => {
+                    return Err(be(
+                        "vulkan Op::QsaBatchAttention K/V segment geometry differs",
+                    ));
+                }
+                (None, None) => (k_cache_buf, v_cache_buf, None),
+                _ => {
+                    return Err(be(
+                            "vulkan Op::QsaBatchAttention K/V caches must both be segmented or both be flat",
+                        ));
+                }
+            };
             rec.qsa_attention_batch(
                 r(*q)?,
-                r(*k_cache)?,
-                r(*v_cache)?,
+                k_binding,
+                v_binding,
                 r(*indices)?,
                 r(*dst)?,
                 *rows,
@@ -2796,6 +2854,7 @@ fn lower_op(
                 vdt == infr_core::DType::Q8_0,
                 graph.desc(*k_cache).numel() as u32,
                 graph.desc(*v_cache).numel() as u32,
+                segment_shift,
             );
         }
         // Fused per-head RMSNorm + RoPE. Peephole (see `kv_write_peephole`): a QkNormRope whose dst

--- a/crates/infr-vulkan/src/adapter.rs
+++ b/crates/infr-vulkan/src/adapter.rs
@@ -117,6 +117,16 @@ fn is_kv_prepass(dt: infr_core::DType) -> bool {
     is_kv_quant(dt) || is_kv_dense_alt(dt) || is_turbo(dt)
 }
 
+/// Return the descriptor-visible address table and log2(elements per physical segment) for a
+/// lazily committed KV buffer. Flat caches deliberately return `None` and keep every established
+/// lowering path byte-for-byte unchanged.
+fn segmented_kv_view(buffer: &dyn Buffer) -> Option<(&dyn Buffer, u32)> {
+    let segmented = crate::as_segmented_kv(buffer)?;
+    let elements = segmented.spec().segment_elements;
+    debug_assert!(elements.is_power_of_two());
+    Some((segmented.table_buffer(), elements.trailing_zeros()))
+}
+
 /// Lever 1 (kv-decode-perf-levers #1): mainline low-bit block quants the DECODE split-K kernel can
 /// dequant INLINE via a coalesced block-amortized decoder (`attn_partial`'s `dqv4`,
 /// `attn_partial_ml_kernel`) — so decode reads the compact cache directly instead of a dequant→f16
@@ -2380,6 +2390,24 @@ fn lower_op(
             let cache_dt = graph.desc(*cache).dtype;
             let cache_q8 = matches!(cache_dt, infr_core::DType::Q8_0);
             let src_f16 = matches!(graph.desc(*src).dtype, infr_core::DType::F16);
+            if let Some((table, segment_shift)) = segmented_kv_view(c) {
+                if !matches!(mode, RopeMode::Static(_)) {
+                    return Err(be(
+                        "vulkan adapter: segmented KV writes require the static recording path",
+                    ));
+                }
+                let off = pos * rs;
+                if cache_q8 {
+                    rec.store_q8_segmented(s, table, n, off, src_f16, 0, segment_shift);
+                } else if cache_dt == infr_core::DType::F16 {
+                    rec.store_f16_off_segmented(s, table, n, off, 0, segment_shift, src_f16);
+                } else {
+                    return Err(be(format!(
+                        "vulkan adapter: segmented KV cache dtype {cache_dt:?} is unsupported"
+                    )));
+                }
+                return Ok(());
+            }
             // Planar scales region begins at byte `cap` = total cache elements.
             let cap = graph.desc(*cache).numel();
             // SWA ring cache: the write for position p lands at row p % cap_rows — the ring only
@@ -2804,12 +2832,51 @@ fn lower_op(
             // on the bound build. `out_buf` stays bound at its write slot in the `_at` method for the
             // store→read barrier. Bit-identical to the bound dispatch.
             let y_addr = out_buf.device_addr();
+            let y_segmented = segmented_kv_view(out_buf);
             match mode {
                 RopeMode::Static(rope_pos) => {
                     let ff = match freq_factors {
                         Some(f) => Some(r(*f)?),
                         None => None,
                     };
+                    if let Some((table, _segment_shift)) = y_segmented {
+                        if ff.is_some() {
+                            return Err(be(
+                                "vulkan adapter: segmented QkNormRope does not support frequency factors",
+                            ));
+                        }
+                        if *x_stride > 0 {
+                            rec.qk_norm_rope_interleaved_segmented(
+                                r(*x)?,
+                                r(*weight)?,
+                                table,
+                                *rows as usize,
+                                *n_head as usize,
+                                *head_dim as usize,
+                                *rope_dim as usize,
+                                *theta,
+                                rope_pos[&positions.0],
+                                fused.unwrap_or(0),
+                                *eps,
+                                *x_stride as usize,
+                            );
+                        } else {
+                            rec.qk_norm_rope_segmented(
+                                r(*x)?,
+                                r(*weight)?,
+                                table,
+                                *rows as usize,
+                                *n_head as usize,
+                                *head_dim as usize,
+                                *rope_dim as usize,
+                                *theta,
+                                rope_pos[&positions.0],
+                                fused.unwrap_or(0),
+                                *eps,
+                            );
+                        }
+                        return Ok(());
+                    }
                     if *x_stride > 0 && ff.is_none() {
                         // Interleaved q+g buffer: read query with stride, skip CopyStrided per head.
                         match y_addr {
@@ -2878,6 +2945,11 @@ fn lower_op(
                     } // x_stride > 0
                 }
                 RopeMode::Dynamic(params) => {
+                    if y_segmented.is_some() {
+                        return Err(be(
+                            "vulkan adapter: segmented QkNormRope requires static recording",
+                        ));
+                    }
                     // gemma4 proportional RoPE (full-attention layers): the ff divisors bind via
                     // the `qk_norm_rope_dyn_ff` variant — pos still comes from `params`.
                     let ff = match freq_factors {
@@ -3128,6 +3200,22 @@ fn lower_op(
             let kv_q8 = k_q8 && v_q8; // coupled (the Dynamic-branch kernels' q8 variant)
                                       // Planar Q8 scales region base = total cache elements (K and V caches share numel).
             let cap = graph.desc(*k_cache).numel();
+            let k_segmented = segmented_kv_view(r(*k_cache)?);
+            let v_segmented = segmented_kv_view(r(*v_cache)?);
+            let segmented_cache = match (k_segmented, v_segmented) {
+                (None, None) => false,
+                (Some((_, ks)), Some((_, vs))) if ks == vs => true,
+                (Some(_), Some(_)) => {
+                    return Err(be(
+                        "vulkan adapter: K/V segmented caches use different segment geometry",
+                    ));
+                }
+                _ => {
+                    return Err(be(
+                        "vulkan adapter: K and V must both be segmented or both be flat",
+                    ));
+                }
+            };
             // Row capacity of the bound cache. An SWA layer's cache may be a RING of fewer rows
             // than the live kv_len (window + ubatch, see the runner's ring sizing): position j
             // then lives at row j % att_cap_rows — the scalar/split kernels derive the same
@@ -3144,6 +3232,11 @@ fn lower_op(
             // shapes that path cannot serve are refused here rather than silently mis-served.
             // `decode_eligible` already forces sinks graphs off the record-once replay tape.
             if let Some(sk) = sinks {
+                if segmented_cache {
+                    return Err(be(
+                        "vulkan adapter: segmented attention does not support attention sinks",
+                    ));
+                }
                 // The scalar sinks build reads `q` and both caches as f16 (the seam's own
                 // producer→consumer dtype flow). Every other KV dtype reaches the tier ladder
                 // through the dequant→f16 prepass below, which this early return skips — so
@@ -3186,6 +3279,11 @@ fn lower_op(
                 return Ok(());
             }
             if let RopeMode::Dynamic(params) = mode {
+                if segmented_cache {
+                    return Err(be(
+                        "vulkan adapter: segmented attention requires static recording",
+                    ));
+                }
                 // Eligibility guarantees rows==1. Scale rides a push constant (gemma4 uses 1.0;
                 // 0.0 → kernel default 1/√hd) and SWA windows ride the window-aware prologue +
                 // partial kernel, so gemma-family decode replays too.
@@ -3461,7 +3559,11 @@ fn lower_op(
                     let sc = pool[&k].as_ref();
                     let src = r(*k_cache)?;
                     if k_q8 {
-                        rec.dequant_q8_f16(src, sc, ne, cap);
+                        if let Some((table, shift)) = segmented_kv_view(src) {
+                            rec.dequant_q8_f16_segmented(table, sc, ne, shift);
+                        } else {
+                            rec.dequant_q8_f16(src, sc, ne, cap);
+                        }
                     } else if matches!(kdt, infr_core::DType::F32) {
                         rec.store_f16(src, sc, ne, 0);
                     } else if is_turbo(kdt) {
@@ -3478,7 +3580,11 @@ fn lower_op(
                     let sc = pool[&k].as_ref();
                     let src = r(*v_cache)?;
                     if v_q8 {
-                        rec.dequant_q8_f16(src, sc, ne, cap);
+                        if let Some((table, shift)) = segmented_kv_view(src) {
+                            rec.dequant_q8_f16_segmented(table, sc, ne, shift);
+                        } else {
+                            rec.dequant_q8_f16(src, sc, ne, cap);
+                        }
                     } else if matches!(vdt, infr_core::DType::F32) {
                         rec.store_f16(src, sc, ne, 0);
                     } else if is_turbo(vdt) {
@@ -3495,6 +3601,10 @@ fn lower_op(
                 // planar read), so force q8-eff off — flash_ok then reduces to `flash_geom`.
                 let k_q8_eff = flash_deq_fmt.is_none() && k_q8 && !deq_k;
                 let v_q8_eff = flash_deq_fmt.is_none() && v_q8 && !deq_v;
+                // Q8 prefill expands both sides into ordinary flat f16 scratch, so it may retain
+                // the existing flash tiers. Any side still backed by an address table must use a
+                // segmented-aware reader.
+                let segmented_read = segmented_cache && (!deq_k || !deq_v);
                 // Prefill, causal, hd==128, standard 1/√hd scale: FlashAttention-2 (split-K
                 // online softmax, no materialized [m,kv] scores). The flash kernel hardcodes
                 // 1/√hd and reads/writes ceil(rows/64)*64 q/dst rows, so guard the scale and
@@ -3513,7 +3623,7 @@ fn lower_op(
                 // through to `split_ok`/the final `else` — `attention_kv_split`/`attention_kv`,
                 // already the scalar decode/short-prefill path, dispatch with no coopmat and no
                 // row-count ceiling, so they're a correct (if slower) fallback for ANY `rows`.
-                let flash_ok = flash_geom && !(k_q8_eff || v_q8_eff);
+                let flash_ok = flash_geom && !segmented_read && !(k_q8_eff || v_q8_eff);
                 // Coopmat prefill shmem-staging mode (Levers 2 & 5). Dequant wins over the pure-f16
                 // stage; both need the flash geometry. INFR_FLASH_STAGE stages the f16 KV (cache, or
                 // the prepass f16 scratch on a quant model) into shmem — the reuse experiment.
@@ -3547,6 +3657,7 @@ fn lower_op(
                     _ => None,
                 };
                 let nonfa_ok = !flash_ok
+                    && !segmented_read
                     && canvas_lo.is_none()
                     && rows >= 64
                     // attn_qk reads K tiles up to ceil(kv_len/256)*256 rows (masked in softmax) —
@@ -3576,6 +3687,7 @@ fn lower_op(
                 // against the scalar/split floor).
                 let nc_fa_ok = !flash_ok
                     && !nonfa_ok
+                    && !segmented_read
                     && !be_.caps().f16_coopmat()
                     && (rows >= 64 || (rows >= flash_min_rows && kv_len >= 8192))
                     && canvas_lo.is_none()
@@ -3607,6 +3719,7 @@ fn lower_op(
                 // decide. Reproduces the old `is_err()`/`is_ok()` pair exactly.
                 let mrows_attn = be_.cfg().kernels.vulkan.mrows_attn;
                 let batched_attn = rows >= 2
+                    && !segmented_read
                     && hd <= 128
                     && kv_len <= att_cap_rows // the mrows kernel has no ring row mapping
                     && canvas_lo.is_none()
@@ -3680,6 +3793,10 @@ fn lower_op(
                     kv_len.div_ceil(n).min(kv_len - 1).max(1)
                 } else if batched_attn {
                     256
+                } else if segmented_read && rows >= 64 {
+                    // `attn_partial`'s score slab holds at most 1024 keys. Use that ceiling to
+                    // minimize partial scratch until the segmented coopmat prefill tier lands.
+                    1024
                 } else if (ring_past || cap_short) && rows >= 64 {
                     // Large-rows ring/capacity-limited prefill: the pm/pl/pacc partials are [rows,
                     // nh, n_chunks, hd] — the ordinary ~32-chunk policy would balloon them (1024
@@ -3707,11 +3824,12 @@ fn lower_op(
                 let chunk = split_k_chunk_count_cap(span, chunk);
                 // Canvas forces the split-K tier regardless of row count (see `canvas_lo` above) —
                 // `attn_partial` carries the fixed `lo` override this mask needs; flash/nonfa don't.
-                let split_ok = (rows < 64 || canvas_lo.is_some() || ring_past || cap_short)
-                    && span > chunk
-                    && hd % 4 == 0
-                    && hd <= 512
-                    && (rows == 1 || !(k_q8_eff || v_q8_eff));
+                let split_ok =
+                    (rows < 64 || segmented_read || canvas_lo.is_some() || ring_past || cap_short)
+                        && (span > chunk || segmented_read)
+                        && hd % 4 == 0
+                        && hd <= 512
+                        && (rows == 1 || !(k_q8_eff || v_q8_eff));
                 if flash_ok {
                     let mpad = rows.div_ceil(64) * 64;
                     // Pooled split partials (fully written before the combine reads them) — one
@@ -3870,58 +3988,94 @@ fn lower_op(
                     // address → the `(Some, Some)` arm). `decode_inline` ⟹ `split_ok` here, so this
                     // is the arm that fires. None for f16/Q8/prefill.
                     let kv_ml = if decode_inline { Some(kdt) } else { None };
-                    match (kcb.device_addr(), vcb.device_addr()) {
-                        (Some(ka), Some(va)) => rec.attention_kv_split_at(
-                            r(*q)?,
-                            kcb,
-                            vcb,
-                            ka,
-                            va,
-                            r(*dst)?,
-                            pool[&pm].as_ref(),
-                            pool[&pl].as_ref(),
-                            pool[&pacc].as_ref(),
-                            rows,
-                            pos,
-                            kv_len,
-                            nh,
-                            nkv,
-                            hd,
-                            chunk,
-                            n_chunks,
-                            *scale,
-                            window,
-                            canvas_lo,
-                            k_q8_eff,
-                            v_q8_eff,
-                            cap,
-                            batched_attn,
-                            kv_ml,
-                        ),
-                        _ => rec.attention_kv_split(
-                            r(*q)?,
-                            kcb,
-                            vcb,
-                            r(*dst)?,
-                            pool[&pm].as_ref(),
-                            pool[&pl].as_ref(),
-                            pool[&pacc].as_ref(),
-                            rows,
-                            pos,
-                            kv_len,
-                            nh,
-                            nkv,
-                            hd,
-                            chunk,
-                            n_chunks,
-                            *scale,
-                            window,
-                            canvas_lo,
-                            k_q8_eff,
-                            v_q8_eff,
-                            cap,
-                            batched_attn,
-                        ),
+                    match (segmented_kv_view(kcb), segmented_kv_view(vcb)) {
+                        (Some((kt, ks)), Some((vt, vs))) if ks == vs => {
+                            rec.attention_kv_split_segmented(
+                                r(*q)?,
+                                kt,
+                                vt,
+                                r(*dst)?,
+                                pool[&pm].as_ref(),
+                                pool[&pl].as_ref(),
+                                pool[&pacc].as_ref(),
+                                rows,
+                                pos,
+                                kv_len,
+                                nh,
+                                nkv,
+                                hd,
+                                chunk,
+                                n_chunks,
+                                *scale,
+                                window,
+                                k_q8_eff,
+                                v_q8_eff,
+                                ks,
+                            );
+                        }
+                        (Some(_), Some(_)) => {
+                            return Err(be(
+                                "vulkan adapter: split attention K/V segment geometry differs",
+                            ));
+                        }
+                        (Some(_), None) | (None, Some(_)) => {
+                            return Err(be(
+                                "vulkan adapter: split attention cannot mix segmented and flat K/V",
+                            ));
+                        }
+                        (None, None) => match (kcb.device_addr(), vcb.device_addr()) {
+                            (Some(ka), Some(va)) => rec.attention_kv_split_at(
+                                r(*q)?,
+                                kcb,
+                                vcb,
+                                ka,
+                                va,
+                                r(*dst)?,
+                                pool[&pm].as_ref(),
+                                pool[&pl].as_ref(),
+                                pool[&pacc].as_ref(),
+                                rows,
+                                pos,
+                                kv_len,
+                                nh,
+                                nkv,
+                                hd,
+                                chunk,
+                                n_chunks,
+                                *scale,
+                                window,
+                                canvas_lo,
+                                k_q8_eff,
+                                v_q8_eff,
+                                cap,
+                                batched_attn,
+                                kv_ml,
+                            ),
+                            _ => rec.attention_kv_split(
+                                r(*q)?,
+                                kcb,
+                                vcb,
+                                r(*dst)?,
+                                pool[&pm].as_ref(),
+                                pool[&pl].as_ref(),
+                                pool[&pacc].as_ref(),
+                                rows,
+                                pos,
+                                kv_len,
+                                nh,
+                                nkv,
+                                hd,
+                                chunk,
+                                n_chunks,
+                                *scale,
+                                window,
+                                canvas_lo,
+                                k_q8_eff,
+                                v_q8_eff,
+                                cap,
+                                batched_attn,
+                            ),
+                        },
                     }
                 } else {
                     let window = match mask {

--- a/crates/infr-vulkan/src/gemm.rs
+++ b/crates/infr-vulkan/src/gemm.rs
@@ -3330,14 +3330,34 @@ macro_rules! qsa_spv {
 qsa_spv!(qsa_indexer_topk_hist_spv, "qsa_indexer_topk_hist");
 qsa_spv!(qsa_indexer_topk_select_spv, "qsa_indexer_topk_select");
 qsa_spv!(qsa_indexer_topk_collect_spv, "qsa_indexer_topk_collect");
+qsa_spv!(qsa_indexer_compress_seg_spv, "qsa_indexer_compress_seg");
+qsa_spv!(qsa_indexer_score_seg_spv, "qsa_indexer_score_seg");
+qsa_spv!(
+    qsa_indexer_score_decode8_seg_spv,
+    "qsa_indexer_score_decode8_seg"
+);
 qsa_spv!(qsa_gather_spv, "qsa_gather");
 qsa_spv!(qsa_gather_kq8_spv, "qsa_gather_kq8");
 qsa_spv!(qsa_gather_vq8_spv, "qsa_gather_vq8");
 qsa_spv!(qsa_gather_q8_spv, "qsa_gather_q8");
+qsa_spv!(qsa_gather_seg_spv, "qsa_gather_seg");
+qsa_spv!(qsa_gather_kq8_seg_spv, "qsa_gather_kq8_seg");
+qsa_spv!(qsa_gather_vq8_seg_spv, "qsa_gather_vq8_seg");
+qsa_spv!(qsa_gather_q8_seg_spv, "qsa_gather_q8_seg");
 qsa_spv!(qsa_attention_batch_spv, "qsa_attention_batch");
 qsa_spv!(qsa_attention_batch_kq8_spv, "qsa_attention_batch_kq8");
 qsa_spv!(qsa_attention_batch_vq8_spv, "qsa_attention_batch_vq8");
 qsa_spv!(qsa_attention_batch_q8_spv, "qsa_attention_batch_q8");
+qsa_spv!(qsa_attention_batch_seg_spv, "qsa_attention_batch_seg");
+qsa_spv!(
+    qsa_attention_batch_kq8_seg_spv,
+    "qsa_attention_batch_kq8_seg"
+);
+qsa_spv!(
+    qsa_attention_batch_vq8_seg_spv,
+    "qsa_attention_batch_vq8_seg"
+);
+qsa_spv!(qsa_attention_batch_q8_seg_spv, "qsa_attention_batch_q8_seg");
 /// SPIR-V for Ling KDA recurrent attention.
 #[cfg_attr(infr_profile, infr_prof::instrument)]
 pub(crate) fn kda_spv() -> &'static [u32] {

--- a/crates/infr-vulkan/src/gemm.rs
+++ b/crates/infr-vulkan/src/gemm.rs
@@ -3603,6 +3603,11 @@ macro_rules! dyn_spv {
 }
 dyn_spv!(qk_norm_rope_dyn_spv, "qk_norm_rope_dyn");
 dyn_spv!(qk_norm_rope_dyn_ff_spv, "qk_norm_rope_dyn_ff");
+dyn_spv!(qk_norm_rope_seg_spv, "qk_norm_rope_seg");
+dyn_spv!(
+    qk_norm_rope_interleaved_seg_spv,
+    "qk_norm_rope_interleaved_seg"
+);
 // Same "read a scalar from a device buffer instead of a push constant" idea, but for
 // DiffusionGemma denoise self-conditioning's softmax scale (`-DUSE_SCALE_BUF`) rather than the
 // record-once decode replay's pos/kv_len — see `Op::Softmax::scale_buf`'s doc and `Recorder::
@@ -3611,8 +3616,15 @@ dyn_spv!(softmax_dyn_spv, "softmax_dyn");
 dyn_spv!(rope_f16_spv, "rope_f16");
 dyn_spv!(rope_f16_dyn_spv, "rope_f16_dyn");
 dyn_spv!(store_f16_dyn_spv, "store_f16_dyn");
+dyn_spv!(store_f16_seg_spv, "store_f16_seg");
+dyn_spv!(store_f16_f16_seg_spv, "store_f16_f16_seg");
 dyn_spv!(attention_kv_dyn_spv, "attention_kv_dyn");
 dyn_spv!(attn_partial_dyn_spv, "attn_partial_dyn");
+dyn_spv!(attn_partial_seg_spv, "attn_partial_seg");
+dyn_spv!(attn_partial_seg_nohd_spv, "attn_partial_seg_nohd");
+dyn_spv!(attn_partial_seg_kq8_spv, "attn_partial_seg_kq8");
+dyn_spv!(attn_partial_seg_vq8_spv, "attn_partial_seg_vq8");
+dyn_spv!(attn_partial_seg_q8_spv, "attn_partial_seg_q8");
 // A/B escape for the hd=256/512 attn_partial fast paths (INFR_NO_ATTN_HD=1): the same three f16
 // form-factors compiled with -DNO_HD_SPEC, so a regression on those shapes is diagnosable
 // against the general per-key loops.
@@ -3652,6 +3664,8 @@ dyn_spv!(store_q8_spv, "store_q8");
 dyn_spv!(store_q8_dyn_spv, "store_q8_dyn");
 dyn_spv!(store_q8_f16_spv, "store_q8_f16");
 dyn_spv!(store_q8_f16_dyn_spv, "store_q8_f16_dyn");
+dyn_spv!(store_q8_seg_spv, "store_q8_seg");
+dyn_spv!(store_q8_f16_seg_spv, "store_q8_f16_seg");
 // Mainline low-bit KV quants: per-format quantize (f32 V / f16 K) + dequant→f16 prefix expander.
 dyn_spv!(quant_kv_q4_0_spv, "quant_kv_q4_0");
 dyn_spv!(quant_kv_q4_0_f16_spv, "quant_kv_q4_0_f16");
@@ -4034,6 +4048,7 @@ pub(crate) fn attn_partial_ml_kernel(
     }
 }
 dyn_spv!(dequant_q8_f16_spv, "dequant_q8_f16");
+dyn_spv!(dequant_q8_f16_seg_spv, "dequant_q8_f16_seg");
 /// SPIR-V for the SELF-CHUNKING record-once split-K decode partial (adaptive chunk from the live
 /// kv_len; workgroups past the live range early-exit with a zero-weight header).
 #[cfg_attr(infr_profile, infr_prof::instrument)]

--- a/crates/infr-vulkan/src/lib.rs
+++ b/crates/infr-vulkan/src/lib.rs
@@ -64,7 +64,7 @@ use gpu_allocator::vulkan::{
 use gpu_allocator::MemoryLocation;
 
 use infr_core::{
-    backend::{Bindings, Buffer, BufferUsage, Capabilities, Plan},
+    backend::{Bindings, Buffer, BufferUsage, Capabilities, Plan, SegmentedKvSpec},
     budget::{spill_report_line, SpillNouns, SpillTally},
     config::Config,
     error::Result,
@@ -808,6 +808,44 @@ impl Buffer for VkBuffer {
             _ => None,
         }
     }
+}
+
+/// A graph-visible full-context KV buffer backed by independently committed physical segments.
+/// The tiny host-visible table stores one device address per live segment; paged KV kernels bind
+/// that table while the ordinary graph continues to carry the original logical tensor extent.
+struct VkSegmentedKvBuffer {
+    shared: Arc<VulkanShared>,
+    spec: SegmentedKvSpec,
+    table: VkBuffer,
+    segments: Mutex<Vec<VkBuffer>>,
+}
+
+impl VkSegmentedKvBuffer {
+    fn committed(&self) -> usize {
+        self.segments.lock().unwrap().len()
+    }
+
+    pub(crate) fn table_buffer(&self) -> &VkBuffer {
+        &self.table
+    }
+
+    pub(crate) fn spec(&self) -> SegmentedKvSpec {
+        self.spec
+    }
+}
+
+impl Buffer for VkSegmentedKvBuffer {
+    fn len_bytes(&self) -> usize {
+        self.spec.logical_bytes
+    }
+
+    fn as_any(&self) -> &dyn std::any::Any {
+        self
+    }
+}
+
+pub(crate) fn as_segmented_kv(b: &dyn Buffer) -> Option<&VkSegmentedKvBuffer> {
+    b.as_any().downcast_ref::<VkSegmentedKvBuffer>()
 }
 
 // ── weight arena ────────────────────────────────────────────────────────────────
@@ -3906,7 +3944,8 @@ impl VulkanBackend {
                 })?;
                 if matches!(
                     class,
-                    crate::unified::UnifiedVramClass::EmbeddingWeights
+                    crate::unified::UnifiedVramClass::KvCache
+                        | crate::unified::UnifiedVramClass::EmbeddingWeights
                         | crate::unified::UnifiedVramClass::VisionWeights
                         | crate::unified::UnifiedVramClass::DraftWeights
                         | crate::unified::UnifiedVramClass::LlmRuntime
@@ -3960,6 +3999,80 @@ impl VulkanBackend {
         class: crate::unified::UnifiedVramClass,
     ) -> Result<Box<dyn Buffer>> {
         Ok(Box::new(self.alloc_unified_buffer(size, class)?) as Box<dyn Buffer>)
+    }
+
+    fn make_segmented_kv(&self, spec: SegmentedKvSpec) -> Result<VkSegmentedKvBuffer> {
+        if spec.logical_bytes == 0
+            || spec.segment_bytes == 0
+            || spec.segment_elements == 0
+            || spec.max_segments == 0
+        {
+            return Err(be(format!(
+                "segmented KV needs non-zero logical bytes, segment bytes and segment count; got {spec:?}"
+            )));
+        }
+        let table_bytes = spec
+            .max_segments
+            .checked_mul(std::mem::size_of::<u64>())
+            .ok_or_else(|| be("segmented KV address-table size overflow"))?;
+        let table = self.make_buf(table_bytes, MemoryLocation::CpuToGpu, "kv-segment-table")?;
+        self.fill_buf(&table, 0)?;
+        Ok(VkSegmentedKvBuffer {
+            shared: Arc::clone(&self.shared),
+            spec,
+            table,
+            segments: Mutex::new(Vec::new()),
+        })
+    }
+
+    fn ensure_segmented_kv_inner(&self, buffer: &VkSegmentedKvBuffer, wanted: usize) -> Result<()> {
+        if !Arc::ptr_eq(&buffer.shared, &self.shared) {
+            return Err(be(
+                "segmented KV buffer belongs to a different Vulkan backend/device",
+            ));
+        }
+        if wanted > buffer.spec.max_segments {
+            return Err(be(format!(
+                "segmented KV requested {wanted} segments, but its logical extent allows only {}",
+                buffer.spec.max_segments
+            )));
+        }
+        self.with_unified_exclusive(|| {
+            let mut segments = buffer.segments.lock().unwrap();
+            while segments.len() < wanted {
+                let segment = if self.unified_vram().is_some() {
+                    self.alloc_unified_buffer_locked(
+                        buffer.spec.segment_bytes,
+                        crate::unified::UnifiedVramClass::KvCache,
+                    )?
+                } else {
+                    self.make_buf_ex(
+                        buffer.spec.segment_bytes,
+                        MemoryLocation::GpuOnly,
+                        "kv-segment",
+                        false,
+                        true,
+                    )?
+                };
+                let addr = segment
+                    .device_addr()
+                    .ok_or_else(|| be("segmented KV physical segment has no device address"))?;
+                let index = segments.len();
+                let table_ptr = buffer
+                    .table
+                    .mapped_ptr()
+                    .ok_or_else(|| be("segmented KV address table is not host-visible"))?;
+                unsafe {
+                    std::ptr::copy_nonoverlapping(
+                        addr.to_ne_bytes().as_ptr(),
+                        table_ptr.add(index * std::mem::size_of::<u64>()),
+                        std::mem::size_of::<u64>(),
+                    );
+                }
+                segments.push(segment);
+            }
+            Ok(())
+        })
     }
 
     /// Sub-allocate `size` bytes for a resident weight tensor from the BDA arena (see
@@ -4687,6 +4800,16 @@ impl Backend for VulkanBackend {
             self.fill_buf(&buf, 0xFF)?;
         }
         Ok(Box::new(buf))
+    }
+
+    fn alloc_segmented_kv(&self, spec: SegmentedKvSpec) -> Result<Option<Box<dyn Buffer>>> {
+        Ok(Some(Box::new(self.make_segmented_kv(spec)?)))
+    }
+
+    fn ensure_segmented_kv(&self, buffer: &dyn Buffer, segments: usize) -> Result<()> {
+        let segmented = as_segmented_kv(buffer)
+            .ok_or_else(|| be("ensure_segmented_kv received a flat or foreign buffer"))?;
+        self.ensure_segmented_kv_inner(segmented, segments)
     }
 
     /// Copy `src` (host slice) into `dst` (device buffer).
@@ -5863,6 +5986,60 @@ mod tests {
         drop(a);
         drop(b);
         assert_eq!(pool.stats().allocated_bytes, 0);
+    }
+
+    /// Segmented KV keeps its graph-visible logical extent while committing only the requested
+    /// physical segments from the elastic arena. Address-table entries are populated once and all
+    /// KV-class bytes return to the arena with the virtual buffer.
+    #[test]
+    #[ignore = "requires a Vulkan-capable GPU"]
+    fn segmented_kv_commits_and_releases_elastic_ranges() {
+        let be = match VulkanBackend::new() {
+            Ok(b) => b,
+            Err(_) => {
+                eprintln!("skip: no Vulkan GPU");
+                return;
+            }
+        };
+        const MIB: usize = 1024 * 1024;
+        let pool = be.init_unified_vram(8 * MIB).expect("init unified VRAM");
+        let virtual_kv = be
+            .alloc_segmented_kv(SegmentedKvSpec {
+                logical_bytes: 4 * MIB,
+                segment_bytes: MIB,
+                segment_elements: MIB / 2,
+                max_segments: 4,
+            })
+            .expect("allocate segmented KV")
+            .expect("Vulkan supports segmented KV");
+        assert_eq!(virtual_kv.len_bytes(), 4 * MIB);
+        let segmented = as_segmented_kv(virtual_kv.as_ref()).expect("segmented downcast");
+        assert_eq!(segmented.committed(), 0);
+
+        be.ensure_segmented_kv(virtual_kv.as_ref(), 2)
+            .expect("commit two segments");
+        assert_eq!(segmented.committed(), 2);
+        assert_eq!(
+            pool.stats()
+                .class_bytes(crate::unified::UnifiedVramClass::KvCache),
+            2 * MIB
+        );
+        let ptr = segmented
+            .table_buffer()
+            .mapped_ptr()
+            .expect("table mapping") as *const u64;
+        let addresses = unsafe { std::slice::from_raw_parts(ptr, 4) };
+        assert_ne!(addresses[0], 0);
+        assert_ne!(addresses[1], 0);
+        assert_ne!(addresses[0], addresses[1]);
+        assert_eq!(addresses[2], 0);
+
+        drop(virtual_kv);
+        assert_eq!(
+            pool.stats()
+                .class_bytes(crate::unified::UnifiedVramClass::KvCache),
+            0
+        );
     }
 
     /// A module allocation may evict cold expert slots, then exact-slot restoration returns every

--- a/crates/infr-vulkan/src/lib.rs
+++ b/crates/infr-vulkan/src/lib.rs
@@ -5870,11 +5870,11 @@ mod tests {
         const MIB: u64 = 1024 * 1024;
         let max = 4 * 1024 * MIB;
 
-        let (first, floor) = bda_block_geometry(1 * MIB, BDA_BLOCK_MIN, max);
+        let (first, floor) = bda_block_geometry(MIB, BDA_BLOCK_MIN, max);
         assert_eq!((first, floor), (64 * MIB, 128 * MIB));
-        let (second, floor) = bda_block_geometry(1 * MIB, floor, max);
+        let (second, floor) = bda_block_geometry(MIB, floor, max);
         assert_eq!((second, floor), (128 * MIB, 256 * MIB));
-        let (third, floor) = bda_block_geometry(1 * MIB, floor, max);
+        let (third, floor) = bda_block_geometry(MIB, floor, max);
         assert_eq!((third, floor), (256 * MIB, 256 * MIB));
 
         let (large, unchanged) = bda_block_geometry(300 * MIB, 128 * MIB, max);

--- a/crates/infr-vulkan/src/lib.rs
+++ b/crates/infr-vulkan/src/lib.rs
@@ -4803,13 +4803,30 @@ impl Backend for VulkanBackend {
     }
 
     fn alloc_segmented_kv(&self, spec: SegmentedKvSpec) -> Result<Option<Box<dyn Buffer>>> {
+        if self.unified_vram().is_none() {
+            return Ok(None);
+        }
         Ok(Some(Box::new(self.make_segmented_kv(spec)?)))
+    }
+
+    fn segmented_kv_available(&self) -> bool {
+        self.unified_vram().is_some()
     }
 
     fn ensure_segmented_kv(&self, buffer: &dyn Buffer, segments: usize) -> Result<()> {
         let segmented = as_segmented_kv(buffer)
             .ok_or_else(|| be("ensure_segmented_kv received a flat or foreign buffer"))?;
         self.ensure_segmented_kv_inner(segmented, segments)
+    }
+
+    fn clear_segmented_kv(&self, buffer: &dyn Buffer) -> Result<()> {
+        let segmented = as_segmented_kv(buffer)
+            .ok_or_else(|| be("clear_segmented_kv received a flat or foreign buffer"))?;
+        let segments = segmented.segments.lock().unwrap();
+        for segment in segments.iter() {
+            self.fill_buf(segment, 0)?;
+        }
+        Ok(())
     }
 
     /// Copy `src` (host slice) into `dst` (device buffer).

--- a/crates/infr-vulkan/src/pager.rs
+++ b/crates/infr-vulkan/src/pager.rs
@@ -2252,6 +2252,7 @@ impl MoePagerSession {
             tracing::debug!(
                 restored_slots = restored,
                 expert_bytes = stats.class_bytes(UnifiedVramClass::Expert),
+                kv_cache_bytes = stats.class_bytes(UnifiedVramClass::KvCache),
                 llm_runtime_bytes = stats.class_bytes(UnifiedVramClass::LlmRuntime),
                 embedding_weight_bytes = stats.class_bytes(UnifiedVramClass::EmbeddingWeights),
                 embedding_runtime_bytes = stats.class_bytes(UnifiedVramClass::EmbeddingRuntime),

--- a/crates/infr-vulkan/src/pager.rs
+++ b/crates/infr-vulkan/src/pager.rs
@@ -1346,7 +1346,8 @@ impl HostStoreChunk {
             .filter(|&end| end <= self.bytes.len())
             .ok_or_else(|| be("host-store copy range out of bounds"))?;
         let len = dst - offset;
-        unsafe { self.bytes.slice_mut(offset, len) }.copy_from_slice(src);
+        debug_assert_eq!(len, src.len());
+        unsafe { self.bytes.copy_from_slice(offset, src) };
         Ok(())
     }
 }
@@ -2139,7 +2140,9 @@ impl MoePagerSession {
             }
         }
         let want = prefill_align(bytes);
-        let mut best: Option<((usize, u128, usize, usize), Vec<(usize, usize)>)> = None;
+        type LoanScore = (usize, u128, usize, usize);
+        type LoanCandidate = (LoanScore, Vec<(usize, usize)>);
+        let mut best: Option<LoanCandidate> = None;
         for (shard, &capacity) in shard_sizes.iter().enumerate() {
             if want > capacity {
                 continue;
@@ -2288,8 +2291,10 @@ impl MoePagerSession {
         if !self.prefill_placement.is_empty() {
             return Ok(());
         }
-        let mut grouped: BTreeMap<u32, Vec<(u8, usize, usize, usize, Option<usize>, usize)>> =
-            BTreeMap::new();
+        type PrefillSource = (u8, usize, usize, usize, Option<usize>, usize);
+        type PackedBank = (usize, usize, usize, usize);
+        type PrefillLayer = (u32, Vec<PackedBank>, usize);
+        let mut grouped: BTreeMap<u32, Vec<PrefillSource>> = BTreeMap::new();
         for (&buf_id, (role, pool, src)) in &self.sources {
             let role_order = match role {
                 Role::Gate => 0,
@@ -2311,7 +2316,7 @@ impl MoePagerSession {
             ));
         }
 
-        let mut layers: Vec<(u32, Vec<(usize, usize, usize, usize)>, usize)> = Vec::new();
+        let mut layers: Vec<PrefillLayer> = Vec::new();
         for (layer_base, mut banks) in grouped {
             banks.sort_unstable_by_key(|&(role, buf_id, _, _, _, _)| (role, buf_id));
             let mut offset = 0usize;

--- a/crates/infr-vulkan/src/recorder.rs
+++ b/crates/infr-vulkan/src/recorder.rs
@@ -5851,6 +5851,39 @@ impl<'a> Recorder<'a> {
         );
     }
 
+    /// Write f32 activations into a lazily committed f16 KV cache. `dst` is the segment address
+    /// table and `segment_shift` is log2(elements per physical segment).
+    #[allow(clippy::too_many_arguments)]
+    pub fn store_f16_off_segmented(
+        &self,
+        src: &dyn Buffer,
+        dst: &dyn Buffer,
+        n: usize,
+        off: usize,
+        src_off: usize,
+        segment_shift: u32,
+        src_f16: bool,
+    ) {
+        let (name, spv) = if src_f16 {
+            ("store_f16_f16_seg", crate::gemm::store_f16_f16_seg_spv())
+        } else {
+            ("store_f16_seg", crate::gemm::store_f16_seg_spv())
+        };
+        let k = self.be.kernel(name, spv, 2, 24);
+        let mut push = [0u8; 24];
+        push[0..4].copy_from_slice(&(n as u32).to_ne_bytes());
+        push[4..8].copy_from_slice(&(off as u32).to_ne_bytes());
+        push[8..12].copy_from_slice(&(src_off as u32).to_ne_bytes());
+        push[12..16].copy_from_slice(&segment_shift.to_ne_bytes());
+        self.dispatch(
+            k,
+            &[Self::vkb(src), Self::vkb(dst)],
+            1,
+            &push,
+            (n as u32).div_ceil(64),
+        );
+    }
+
     /// `-DKV_BDA` twin of [`Self::store_f16_dyn`]: writes the f16 cache at `dst_addr` (row from
     /// `params`). `dst` stays bound at slot 2 (inert) for the store→read barrier.
     pub fn store_f16_dyn_at(
@@ -6026,6 +6059,47 @@ impl<'a> Recorder<'a> {
         }
     }
 
+    /// Fused QK-norm + RoPE write into a segmented f16 K cache. The segment size is derived from
+    /// the Qwen row width and the fixed 32K growth quantum in the shader.
+    #[allow(clippy::too_many_arguments)]
+    pub fn qk_norm_rope_segmented(
+        &self,
+        x: &dyn Buffer,
+        nw: &dyn Buffer,
+        y: &dyn Buffer,
+        rows: usize,
+        nheads: usize,
+        hd: usize,
+        rope_dim: usize,
+        theta: f32,
+        rope_pos: usize,
+        out_base: usize,
+        eps: f32,
+    ) {
+        let k = self.be.kernel(
+            "qk_norm_rope_seg",
+            crate::gemm::qk_norm_rope_seg_spv(),
+            3,
+            44,
+        );
+        let mut push = [0u8; 44];
+        push[0..4].copy_from_slice(&(rows as u32).to_ne_bytes());
+        push[4..8].copy_from_slice(&(nheads as u32).to_ne_bytes());
+        push[8..12].copy_from_slice(&(hd as u32).to_ne_bytes());
+        push[12..16].copy_from_slice(&(rope_dim as u32).to_ne_bytes());
+        push[16..20].copy_from_slice(&theta.to_ne_bytes());
+        push[20..24].copy_from_slice(&(rope_pos as u32).to_ne_bytes());
+        push[24..28].copy_from_slice(&(out_base as u32).to_ne_bytes());
+        push[28..32].copy_from_slice(&eps.to_ne_bytes());
+        self.dispatch(
+            k,
+            &[Self::vkb(x), Self::vkb(nw), Self::vkb(y)],
+            1,
+            &push,
+            (rows * nheads) as u32,
+        );
+    }
+
     /// `-DKV_BDA` twin of [`Self::qk_norm_rope_interleaved`]: writes the fused K cache at `y_addr`.
     /// `y` stays bound at slot 2 (inert) for the store→read barrier.
     #[allow(clippy::too_many_arguments)]
@@ -6063,6 +6137,48 @@ impl<'a> Recorder<'a> {
         push[32..36].copy_from_slice(&(src_stride as u32).to_ne_bytes());
         push[36..40].copy_from_slice(&(y_addr as u32).to_ne_bytes());
         push[40..44].copy_from_slice(&((y_addr >> 32) as u32).to_ne_bytes());
+        self.dispatch(
+            k,
+            &[Self::vkb(qg), Self::vkb(nw), Self::vkb(y)],
+            1,
+            &push,
+            (rows * nheads) as u32,
+        );
+    }
+
+    /// Interleaved-source twin of [`Self::qk_norm_rope_segmented`].
+    #[allow(clippy::too_many_arguments)]
+    pub fn qk_norm_rope_interleaved_segmented(
+        &self,
+        qg: &dyn Buffer,
+        nw: &dyn Buffer,
+        y: &dyn Buffer,
+        rows: usize,
+        nheads: usize,
+        hd: usize,
+        rope_dim: usize,
+        theta: f32,
+        rope_pos: usize,
+        out_base: usize,
+        eps: f32,
+        src_stride: usize,
+    ) {
+        let k = self.be.kernel(
+            "qk_norm_rope_interleaved_seg",
+            crate::gemm::qk_norm_rope_interleaved_seg_spv(),
+            3,
+            44,
+        );
+        let mut push = [0u8; 44];
+        push[0..4].copy_from_slice(&(rows as u32).to_ne_bytes());
+        push[4..8].copy_from_slice(&(nheads as u32).to_ne_bytes());
+        push[8..12].copy_from_slice(&(hd as u32).to_ne_bytes());
+        push[12..16].copy_from_slice(&(rope_dim as u32).to_ne_bytes());
+        push[16..20].copy_from_slice(&theta.to_ne_bytes());
+        push[20..24].copy_from_slice(&(rope_pos as u32).to_ne_bytes());
+        push[24..28].copy_from_slice(&(out_base as u32).to_ne_bytes());
+        push[28..32].copy_from_slice(&eps.to_ne_bytes());
+        push[32..36].copy_from_slice(&(src_stride as u32).to_ne_bytes());
         self.dispatch(
             k,
             &[Self::vkb(qg), Self::vkb(nw), Self::vkb(y)],
@@ -6237,6 +6353,39 @@ impl<'a> Recorder<'a> {
         );
     }
 
+    /// Quantize into a segmented planar-Q8 KV cache. Each physical segment owns its local code and
+    /// scale planes, avoiding any relocation when the logical context crosses a 32K boundary.
+    #[allow(clippy::too_many_arguments)]
+    pub fn store_q8_segmented(
+        &self,
+        src: &dyn Buffer,
+        dst: &dyn Buffer,
+        n: usize,
+        off: usize,
+        src_f16: bool,
+        src_off: usize,
+        segment_shift: u32,
+    ) {
+        let (name, spv) = if src_f16 {
+            ("store_q8_f16_seg", crate::gemm::store_q8_f16_seg_spv())
+        } else {
+            ("store_q8_seg", crate::gemm::store_q8_seg_spv())
+        };
+        let k = self.be.kernel(name, spv, 2, 24);
+        let mut push = [0u8; 24];
+        push[0..4].copy_from_slice(&(n as u32).to_ne_bytes());
+        push[4..8].copy_from_slice(&(off as u32).to_ne_bytes());
+        push[8..12].copy_from_slice(&segment_shift.to_ne_bytes());
+        push[12..16].copy_from_slice(&(src_off as u32).to_ne_bytes());
+        self.dispatch(
+            k,
+            &[Self::vkb(src), Self::vkb(dst)],
+            1,
+            &push,
+            (n as u32) / 32,
+        );
+    }
+
     /// Record-once decode variant of [`Recorder::store_q8`]: the write offset is `p_pos*n` (one KV
     /// row at the token's position), `p_pos` read from the `params` SSBO so the buffer replays.
     pub fn store_q8_dyn(
@@ -6292,6 +6441,33 @@ impl<'a> Recorder<'a> {
         push[4..8].copy_from_slice(&(cap as u32).to_ne_bytes());
         push[8..12].copy_from_slice(&(src_addr as u32).to_ne_bytes());
         push[12..16].copy_from_slice(&((src_addr >> 32) as u32).to_ne_bytes());
+        self.dispatch(
+            k,
+            &[Self::vkb(src), Self::vkb(dst)],
+            1,
+            &push,
+            (n as u32).div_ceil(64),
+        );
+    }
+
+    /// Expand a segmented planar-Q8 prefix into contiguous f16 scratch for the existing prefill
+    /// attention kernels.
+    pub fn dequant_q8_f16_segmented(
+        &self,
+        src: &dyn Buffer,
+        dst: &dyn Buffer,
+        n: usize,
+        segment_shift: u32,
+    ) {
+        let k = self.be.kernel(
+            "dequant_q8_f16_seg",
+            crate::gemm::dequant_q8_f16_seg_spv(),
+            2,
+            16,
+        );
+        let mut push = [0u8; 16];
+        push[0..4].copy_from_slice(&(n as u32).to_ne_bytes());
+        push[4..8].copy_from_slice(&segment_shift.to_ne_bytes());
         self.dispatch(
             k,
             &[Self::vkb(src), Self::vkb(dst)],
@@ -6624,7 +6800,7 @@ impl<'a> Recorder<'a> {
     ) {
         self.attention_kv_split_impl(
             q, kc, vc, o, pm, pl, pacc, rows, pos, kv_len, nh, nkv, hd, chunk, n_chunks, scale,
-            window, canvas_lo, k_q8, v_q8, cap, batched, None, None,
+            window, canvas_lo, k_q8, v_q8, cap, batched, None, None, None,
         );
     }
 
@@ -6691,6 +6867,62 @@ impl<'a> Recorder<'a> {
             batched,
             Some((k_addr, v_addr)),
             kv_ml,
+            None,
+        );
+    }
+
+    /// Split-K attention over lazily committed KV segments. `kc`/`vc` are segment address tables;
+    /// `segment_shift` is log2(elements per physical segment) and is identical for K and V.
+    #[allow(clippy::too_many_arguments)]
+    pub fn attention_kv_split_segmented(
+        &self,
+        q: &dyn Buffer,
+        kc: &dyn Buffer,
+        vc: &dyn Buffer,
+        o: &dyn Buffer,
+        pm: &dyn Buffer,
+        pl: &dyn Buffer,
+        pacc: &dyn Buffer,
+        rows: usize,
+        pos: usize,
+        kv_len: usize,
+        nh: usize,
+        nkv: usize,
+        hd: usize,
+        chunk: usize,
+        n_chunks: usize,
+        scale: f32,
+        window: usize,
+        k_q8: bool,
+        v_q8: bool,
+        segment_shift: u32,
+    ) {
+        self.attention_kv_split_impl(
+            q,
+            kc,
+            vc,
+            o,
+            pm,
+            pl,
+            pacc,
+            rows,
+            pos,
+            kv_len,
+            nh,
+            nkv,
+            hd,
+            chunk,
+            n_chunks,
+            scale,
+            window,
+            None,
+            k_q8,
+            v_q8,
+            segment_shift as usize,
+            false,
+            None,
+            None,
+            Some(segment_shift),
         );
     }
 
@@ -6743,11 +6975,36 @@ impl<'a> Recorder<'a> {
         // no dequant→f16 prepass). Only ever set with `kv_addr` Some (inline decode needs the BDA
         // base) and with `k_q8`/`v_q8`/`batched` false (mainline is a distinct read path).
         kv_ml: Option<infr_core::DType>,
+        // Lazily committed cache: bindings 1/2 are address tables and `cap` carries this shift.
+        // Kept separate from a zero BDA base so no existing flat-cache state changes meaning.
+        kv_segment_shift: Option<u32>,
     ) {
-        let bda = kv_addr.is_some();
+        let segmented = kv_segment_shift.is_some();
+        debug_assert!(!(segmented && (kv_addr.is_some() || kv_ml.is_some() || batched)));
+        let bda = kv_addr.is_some() || segmented;
         // pass 1: per-chunk partials (subgroup-reduction QK; needs requiredSubgroupSize=32). Each
         // f16 variant has a `_bda` twin selected when `kv_addr` is Some (device-address K/V reads).
-        let (p1name, p1spv) = if let Some(dt) = kv_ml {
+        let (p1name, p1spv) = if segmented {
+            match (k_q8, v_q8) {
+                (false, false) if crate::gemm::attn_hd_spec_disabled(self.vk()) => (
+                    "attn_partial_seg_nohd",
+                    crate::gemm::attn_partial_seg_nohd_spv(),
+                ),
+                (false, false) => ("attn_partial_seg", crate::gemm::attn_partial_seg_spv()),
+                (true, false) => (
+                    "attn_partial_seg_kq8",
+                    crate::gemm::attn_partial_seg_kq8_spv(),
+                ),
+                (false, true) => (
+                    "attn_partial_seg_vq8",
+                    crate::gemm::attn_partial_seg_vq8_spv(),
+                ),
+                (true, true) => (
+                    "attn_partial_seg_q8",
+                    crate::gemm::attn_partial_seg_q8_spv(),
+                ),
+            }
+        } else if let Some(dt) = kv_ml {
             // Lever 1: mainline low-bit KV decode reads the cache INLINE (per-format FMT build).
             debug_assert!(bda && !k_q8 && !v_q8 && !batched);
             crate::gemm::attn_partial_ml_kernel(dt, crate::gemm::attn_hd_spec_disabled(self.vk()))
@@ -6831,8 +7088,9 @@ impl<'a> Recorder<'a> {
         // but the row bound is checked rather than inferred, since a wrong answer here is silent
         // garbage rather than a crash. `window > 0` needs no such check: those builds carry the
         // modulo, which is the identity when the cache happens to be full-context.
-        let ring_safe = window > 0 || cap == 0 || pos < cap / (nkv * hd);
+        let ring_safe = segmented || window > 0 || cap == 0 || pos < cap / (nkv * hd);
         let fast = if !batched
+            && !segmented
             && !crate::gemm::attn_decode_disabled(self.vk())
             && bda
             && kv_ml.is_none()
@@ -6900,7 +7158,8 @@ impl<'a> Recorder<'a> {
         p1[20..24].copy_from_slice(&(n_chunks as u32).to_ne_bytes());
         p1[24..28].copy_from_slice(&(window as u32).to_ne_bytes());
         p1[28..32].copy_from_slice(&scale.to_ne_bytes());
-        p1[32..36].copy_from_slice(&(cap as u32).to_ne_bytes());
+        let cap_field = kv_segment_shift.unwrap_or(cap as u32);
+        p1[32..36].copy_from_slice(&cap_field.to_ne_bytes());
         p1[36..40].copy_from_slice(&(pos as u32).to_ne_bytes());
         // `rows` is dead in `attn_partial.comp` (this slot carries `canvas_lo+1`, 0 = disabled,
         // instead — see `canvas_lo`'s doc above) but `attn_partial_mrows.comp` (the `batched`

--- a/crates/infr-vulkan/src/recorder.rs
+++ b/crates/infr-vulkan/src/recorder.rs
@@ -8649,18 +8649,27 @@ impl<'a> Recorder<'a> {
         theta: f32,
         eps: f32,
         scale: f32,
+        segment_shifts: Option<(u32, u32)>,
     ) {
         let blocks = kv_len / ratio;
         let first_new = compress_from.min(blocks);
         let new_blocks = blocks - first_new;
         if new_blocks > 0 {
-            let compress_k = self.be.kernel(
-                "qsa_indexer_compress",
-                crate::gemm::qsa_indexer_compress_spv(),
-                3,
-                28,
-            );
-            let mut push = [0u8; 28];
+            let (name, spv, push_bytes) = if segment_shifts.is_some() {
+                (
+                    "qsa_indexer_compress_seg",
+                    crate::gemm::qsa_indexer_compress_seg_spv(),
+                    36,
+                )
+            } else {
+                (
+                    "qsa_indexer_compress",
+                    crate::gemm::qsa_indexer_compress_spv(),
+                    28,
+                )
+            };
+            let compress_k = self.be.kernel(name, spv, 3, push_bytes);
+            let mut push = [0u8; 36];
             push[0..4].copy_from_slice(&first_new.to_ne_bytes());
             push[4..8].copy_from_slice(&new_blocks.to_ne_bytes());
             push[8..12].copy_from_slice(&head_dim.to_ne_bytes());
@@ -8668,6 +8677,10 @@ impl<'a> Recorder<'a> {
             push[16..20].copy_from_slice(&rope_dim.to_ne_bytes());
             push[20..24].copy_from_slice(&theta.to_ne_bytes());
             push[24..28].copy_from_slice(&eps.to_ne_bytes());
+            if let Some((raw_shift, block_shift)) = segment_shifts {
+                push[28..32].copy_from_slice(&raw_shift.to_ne_bytes());
+                push[32..36].copy_from_slice(&block_shift.to_ne_bytes());
+            }
             self.dispatch_wide(
                 compress_k,
                 &[
@@ -8676,18 +8689,33 @@ impl<'a> Recorder<'a> {
                     Self::vkb(block_cache),
                 ],
                 1,
-                &push,
+                &push[..push_bytes as usize],
                 new_blocks,
             );
         }
 
         let decode8 = rows == 1 && self.vk().qsa_score_decode8;
-        let (score_name, score_spv, block_tile, query_tile) = if decode8 {
+        let segmented = segment_shifts.is_some();
+        let (score_name, score_spv, block_tile, query_tile) = if decode8 && segmented {
+            (
+                "qsa_indexer_score_decode8_seg",
+                crate::gemm::qsa_indexer_score_decode8_seg_spv(),
+                8,
+                1,
+            )
+        } else if decode8 {
             (
                 "qsa_indexer_score_decode8",
                 crate::gemm::qsa_indexer_score_decode8_spv(),
                 8,
                 1,
+            )
+        } else if segmented {
+            (
+                "qsa_indexer_score_seg",
+                crate::gemm::qsa_indexer_score_seg_spv(),
+                4,
+                2,
             )
         } else {
             (
@@ -8697,19 +8725,25 @@ impl<'a> Recorder<'a> {
                 2,
             )
         };
-        let score_k = self.be.kernel_sg(score_name, score_spv, 3, 24, 32);
-        let mut push = [0u8; 24];
+        let score_push_bytes = if segmented { 28 } else { 24 };
+        let score_k = self
+            .be
+            .kernel_sg(score_name, score_spv, 3, score_push_bytes, 32);
+        let mut push = [0u8; 28];
         push[0..4].copy_from_slice(&rows.to_ne_bytes());
         push[4..8].copy_from_slice(&kv_len.to_ne_bytes());
         push[8..12].copy_from_slice(&n_head.to_ne_bytes());
         push[12..16].copy_from_slice(&head_dim.to_ne_bytes());
         push[16..20].copy_from_slice(&ratio.to_ne_bytes());
         push[20..24].copy_from_slice(&scale.to_ne_bytes());
+        if let Some((_, block_shift)) = segment_shifts {
+            push[24..28].copy_from_slice(&block_shift.to_ne_bytes());
+        }
         self.dispatch3(
             score_k,
             &[Self::vkb(q), Self::vkb(block_cache), Self::vkb(scores)],
             1,
-            &push,
+            &push[..score_push_bytes as usize],
             blocks.div_ceil(block_tile),
             rows.div_ceil(query_tile),
             1,
@@ -8807,27 +8841,46 @@ impl<'a> Recorder<'a> {
         v_q8: bool,
         kcap: u32,
         vcap: u32,
+        segment_shift: Option<u32>,
     ) {
-        let (name, spv) = match (k_q8, v_q8) {
-            (false, false) => (
+        let segmented = segment_shift.is_some();
+        let (name, spv) = match (k_q8, v_q8, segmented) {
+            (false, false, true) => (
+                "qsa_attention_batch_seg",
+                crate::gemm::qsa_attention_batch_seg_spv(),
+            ),
+            (true, false, true) => (
+                "qsa_attention_batch_kq8_seg",
+                crate::gemm::qsa_attention_batch_kq8_seg_spv(),
+            ),
+            (false, true, true) => (
+                "qsa_attention_batch_vq8_seg",
+                crate::gemm::qsa_attention_batch_vq8_seg_spv(),
+            ),
+            (true, true, true) => (
+                "qsa_attention_batch_q8_seg",
+                crate::gemm::qsa_attention_batch_q8_seg_spv(),
+            ),
+            (false, false, false) => (
                 "qsa_attention_batch",
                 crate::gemm::qsa_attention_batch_spv(),
             ),
-            (true, false) => (
+            (true, false, false) => (
                 "qsa_attention_batch_kq8",
                 crate::gemm::qsa_attention_batch_kq8_spv(),
             ),
-            (false, true) => (
+            (false, true, false) => (
                 "qsa_attention_batch_vq8",
                 crate::gemm::qsa_attention_batch_vq8_spv(),
             ),
-            (true, true) => (
+            (true, true, false) => (
                 "qsa_attention_batch_q8",
                 crate::gemm::qsa_attention_batch_q8_spv(),
             ),
         };
-        let kernel = self.be.kernel_sg(name, spv, 5, 40, 32);
-        let mut push = [0u8; 40];
+        let push_bytes = if segmented { 44 } else { 40 };
+        let kernel = self.be.kernel_sg(name, spv, 5, push_bytes, 32);
+        let mut push = [0u8; 44];
         for (i, value) in [
             rows,
             kv_len,
@@ -8845,6 +8898,9 @@ impl<'a> Recorder<'a> {
         {
             push[i * 4..i * 4 + 4].copy_from_slice(&value.to_ne_bytes());
         }
+        if let Some(shift) = segment_shift {
+            push[40..44].copy_from_slice(&shift.to_ne_bytes());
+        }
         self.dispatch_wide(
             kernel,
             &[
@@ -8855,7 +8911,7 @@ impl<'a> Recorder<'a> {
                 Self::vkb(dst),
             ],
             1,
-            &push,
+            &push[..push_bytes as usize],
             rows.saturating_mul(n_head),
         );
     }
@@ -8877,17 +8933,24 @@ impl<'a> Recorder<'a> {
         v_q8: bool,
         kcap: u32,
         vcap: u32,
+        segment_shift: Option<u32>,
     ) {
         let row_pairs = row_elems / 2;
         let total_pairs = (selected * ratio + tail) * row_pairs;
-        let (name, spv) = match (k_q8, v_q8) {
-            (false, false) => ("qsa_gather", crate::gemm::qsa_gather_spv()),
-            (true, false) => ("qsa_gather_kq8", crate::gemm::qsa_gather_kq8_spv()),
-            (false, true) => ("qsa_gather_vq8", crate::gemm::qsa_gather_vq8_spv()),
-            (true, true) => ("qsa_gather_q8", crate::gemm::qsa_gather_q8_spv()),
+        let segmented = segment_shift.is_some();
+        let (name, spv) = match (k_q8, v_q8, segmented) {
+            (false, false, true) => ("qsa_gather_seg", crate::gemm::qsa_gather_seg_spv()),
+            (true, false, true) => ("qsa_gather_kq8_seg", crate::gemm::qsa_gather_kq8_seg_spv()),
+            (false, true, true) => ("qsa_gather_vq8_seg", crate::gemm::qsa_gather_vq8_seg_spv()),
+            (true, true, true) => ("qsa_gather_q8_seg", crate::gemm::qsa_gather_q8_seg_spv()),
+            (false, false, false) => ("qsa_gather", crate::gemm::qsa_gather_spv()),
+            (true, false, false) => ("qsa_gather_kq8", crate::gemm::qsa_gather_kq8_spv()),
+            (false, true, false) => ("qsa_gather_vq8", crate::gemm::qsa_gather_vq8_spv()),
+            (true, true, false) => ("qsa_gather_q8", crate::gemm::qsa_gather_q8_spv()),
         };
-        let kernel = self.be.kernel(name, spv, 5, 32);
-        let mut push = [0u8; 32];
+        let push_bytes = if segmented { 36 } else { 32 };
+        let kernel = self.be.kernel(name, spv, 5, push_bytes);
+        let mut push = [0u8; 36];
         push[0..4].copy_from_slice(&selected.to_ne_bytes());
         push[4..8].copy_from_slice(&complete.to_ne_bytes());
         push[8..12].copy_from_slice(&tail.to_ne_bytes());
@@ -8896,6 +8959,9 @@ impl<'a> Recorder<'a> {
         push[20..24].copy_from_slice(&total_pairs.to_ne_bytes());
         push[24..28].copy_from_slice(&kcap.to_ne_bytes());
         push[28..32].copy_from_slice(&vcap.to_ne_bytes());
+        if let Some(shift) = segment_shift {
+            push[32..36].copy_from_slice(&shift.to_ne_bytes());
+        }
         self.dispatch(
             kernel,
             &[
@@ -8906,7 +8972,7 @@ impl<'a> Recorder<'a> {
                 Self::vkb(vd),
             ],
             2,
-            &push,
+            &push[..push_bytes as usize],
             total_pairs.div_ceil(256),
         );
     }

--- a/crates/infr-vulkan/src/unified.rs
+++ b/crates/infr-vulkan/src/unified.rs
@@ -16,6 +16,7 @@ use super::{as_vk_buf, be, VulkanBackend};
 #[derive(Clone, Copy, Debug, PartialEq, Eq, Hash)]
 pub enum UnifiedVramClass {
     Expert,
+    KvCache,
     LlmRuntime,
     EmbeddingWeights,
     EmbeddingRuntime,
@@ -26,18 +27,19 @@ pub enum UnifiedVramClass {
 }
 
 impl UnifiedVramClass {
-    const COUNT: usize = 8;
+    const COUNT: usize = 9;
 
     const fn index(self) -> usize {
         match self {
             Self::Expert => 0,
-            Self::LlmRuntime => 1,
-            Self::EmbeddingWeights => 2,
-            Self::EmbeddingRuntime => 3,
-            Self::VisionWeights => 4,
-            Self::VisionRuntime => 5,
-            Self::DraftWeights => 6,
-            Self::DraftRuntime => 7,
+            Self::KvCache => 1,
+            Self::LlmRuntime => 2,
+            Self::EmbeddingWeights => 3,
+            Self::EmbeddingRuntime => 4,
+            Self::VisionWeights => 5,
+            Self::VisionRuntime => 6,
+            Self::DraftWeights => 7,
+            Self::DraftRuntime => 8,
         }
     }
 }

--- a/crates/infr-vulkan/tests/qsa_parity.rs
+++ b/crates/infr-vulkan/tests/qsa_parity.rs
@@ -121,6 +121,7 @@ fn qsa_index_and_gather_match_reference() {
         theta,
         eps,
         scale,
+        None,
     );
     rec.qsa_gather(
         k.as_ref(),
@@ -137,6 +138,7 @@ fn qsa_index_and_gather_match_reference() {
         false,
         0,
         0,
+        None,
     );
     rec.finish().unwrap();
 
@@ -194,6 +196,7 @@ fn qsa_index_and_gather_match_reference() {
         true,
         cap as u32,
         cap as u32,
+        None,
     );
     rec.finish().unwrap();
     be.download(kd.as_ref(), &mut got_k).unwrap();
@@ -229,6 +232,7 @@ fn qsa_index_and_gather_match_reference() {
         theta,
         eps,
         scale,
+        None,
     );
     rec.finish().unwrap();
     be.download(ids.as_ref(), &mut ib).unwrap();
@@ -401,6 +405,7 @@ fn qsa_batched_rows_match_causal_reference() {
         theta,
         eps,
         index_scale,
+        None,
     );
     rec.qsa_attention_batch(
         attn_q.as_ref(),
@@ -420,6 +425,7 @@ fn qsa_batched_rows_match_causal_reference() {
         false,
         0,
         0,
+        None,
     );
     rec.finish().unwrap();
 
@@ -467,6 +473,7 @@ fn qsa_batched_rows_match_causal_reference() {
         true,
         cap as u32,
         cap as u32,
+        None,
     );
     rec.finish().unwrap();
     let mut q8_out_bytes = vec![0u8; want_out.len() * 4];

--- a/crates/infr-vulkan/tests/qsa_parity.rs
+++ b/crates/infr-vulkan/tests/qsa_parity.rs
@@ -35,19 +35,19 @@ fn qsa_index_and_gather_match_reference() {
 
     let mut scores_ref = vec![0.0f32; blocks];
     let mut key = vec![0.0f32; hd];
-    for block in 0..blocks {
-        for d in 0..hd {
-            key[d] = (0..ratio)
+    for (block, score) in scores_ref.iter_mut().enumerate() {
+        for (d, value) in key.iter_mut().enumerate() {
+            *value = (0..ratio)
                 .map(|r| h(&rawb, (block * ratio + r) * hd + d))
                 .sum::<f32>()
                 / ratio as f32;
-            key[d] = half::f16::from_f32(key[d]).to_f32();
+            *value = half::f16::from_f32(*value).to_f32();
         }
         let inv = (key.iter().map(|v| v * v).sum::<f32>() / hd as f32 + eps)
             .sqrt()
             .recip();
-        for d in 0..hd {
-            key[d] *= inv * norm[d];
+        for (value, &weight) in key.iter_mut().zip(&norm) {
+            *value *= inv * weight;
         }
         for pair in 0..rope_dim / 2 {
             let d = 2 * pair;
@@ -59,7 +59,7 @@ fn qsa_index_and_gather_match_reference() {
         }
         for head in 0..nh {
             let dot = (0..hd).map(|d| h(&qb, head * hd + d) * key[d]).sum::<f32>();
-            scores_ref[block] += dot.max(0.0) * scale;
+            *score += dot.max(0.0) * scale;
         }
     }
     let mut rank: Vec<usize> = (0..blocks).collect();
@@ -277,18 +277,18 @@ fn qsa_batched_rows_match_causal_reference() {
         let blocks = visible / ratio;
         let mut scores = vec![0.0f32; blocks];
         for (block, score) in scores.iter_mut().enumerate() {
-            for d in 0..index_hd {
-                key[d] = (0..ratio)
+            for (d, value) in key.iter_mut().enumerate() {
+                *value = (0..ratio)
                     .map(|r| h(&rawb, (block * ratio + r) * index_hd + d))
                     .sum::<f32>()
                     / ratio as f32;
-                key[d] = half::f16::from_f32(key[d]).to_f32();
+                *value = half::f16::from_f32(*value).to_f32();
             }
             let inv = (key.iter().map(|v| v * v).sum::<f32>() / index_hd as f32 + eps)
                 .sqrt()
                 .recip();
-            for d in 0..index_hd {
-                key[d] *= inv * norm[d];
+            for (value, &weight) in key.iter_mut().zip(&norm) {
+                *value *= inv * weight;
             }
             for pair in 0..rope_dim / 2 {
                 let d = 2 * pair;

--- a/docs/backlog.md
+++ b/docs/backlog.md
@@ -879,15 +879,20 @@ residue worth tracking; what follows is that plus what was deliberately left.
   currently sizes it against HOST memory the way `paging.dram` now is. Needs an
   APU to answer. Metal is a separate question: it has no pager at all until
   phase 4, so it inherits none of this yet.
-- **Layer-major prefill LANDED; what is left is where it does not reach.** The
-  chunk loop now runs inside the layer loop for a streamed model
+- **Layer-major prefill is now explicit-only.** It originally made the chunk
+  loop run inside the layer loop for a streamed model
   (`seam::layer_major_prefill`, the `spans`/`chunks` walk in
   `generate_dense_backend`), so a prompt sweeps the weight set once instead of
   once per chunk. Re-measured on the B36 shape — Qwen3-14B Q8_0 / RX 7900 XTX,
   `MemoryMax=8G`, `paging.cache=2g`, `paging.dram=6g`, P=4096, three rounds with
   the arm order permuted and a cold page cache before every run — at the
   1024-row default chunk: 25.27 → 6.31 GB read and 341.9 → 779.9 pp t/s, the
-  read volume now exactly a single-chunk prefill's. The residue:
+  read volume now exactly a single-chunk prefill's. A later automatic Qwen3.8
+  paged-MoE extension did not generalize: on Q2 pp4096, chunk-major measured
+  169.44-205.00 tok/s at ubatch 1024-2048 against layer-major's 11.44-13.34.
+  Unset and `paging.layer_major=false` therefore use chunk-major everywhere;
+  `paging.layer_major=true` retains the implementation for explicit A/B. The
+  original dense experiment's residue remains useful context:
   - **The remaining gap to the single-chunk arm is HOST cost, not I/O.** Same
     6.31 GB, but 779.9 t/s against 1049.6: layer-major builds and compiles a
     graph per (layer, chunk) — 40 x 4 here — where the one-chunk arm builds one.


### PR DESCRIPTION
为 Qwen3.5、Qwen3.6 和 Qwen3.8-Flash-Next 引入动态 KV Cache。
Vulkan Q8 KV 现在按 32K token 分段增长，不再启动时占满整个上下文窗口。
Qwen3.8 的 QSA Index Cache 同步采用分段分配，进一步降低浅上下文显存占用。
修复 Qwen3.8 分页 MoE 错误自动启用 layer-major 导致的严重 Prefill 性能回退。
Qwen3.8 Q2 pp4096 实测由约 11.44–13.34 tok/s 提升至 169.44–205.00 tok/s，约提升 15 倍。
Chunk-major 恢复为所有模型的默认 Prefill 执行方式。
Layer-major 保留为诊断功能，可通过 paging.layer_major=true 显式启用。
兼容的 Vulkan 模型现在默认使用 Q8_0 K/V Cache，显式指定的 KV 类型仍具有最高优先级。
修复自动预算按 F16 估算、运行时却实际分配 Q8 KV 的不一致问题。
统一模型规划、实际分配、日志报告、Synthetic Depth 和会话复制使用的 KV 格式。
修复分段 KV 在跨越 32K 边界时的读写、Attention、Q8 解量化及 QSA Gather/Indexer 路径。
修复 OpenAI 兼容接口的缓存 Prompt token 统计，新增 token 与缓存 token 现在分别报告。
清理 Rust 1.97 workspace lint，改善新版工具链构建兼容性。
当前动态分段仅适用于受支持 Qwen Vulkan 路径上的 Q8_0/Q8_0 KV；显式 F16 或混合 KV 继续使用原有连续分配方式。