### PR TITLE
Fix/qwen3.8 flash next

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,14 @@ The format follows [Keep a Changelog](https://keepachangelog.com/en/1.1.0/).
 
 ## [Unreleased]
 
+## [0.5.1] - 2026-08-31
+
+### Fixed
+
+- Vulkan MoE prefill now reserves its complete-layer lanes before phase scratch allocations.
+  This prevents unified-VRAM fragmentation from causing long-context prefill allocation failures,
+  especially while elastic K/V caches grow across segment boundaries.
+
 ## [0.5.0] - 2026-08-30
 
 ### Highlights

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1124,7 +1124,7 @@ dependencies = [
 
 [[package]]
 name = "infr-chat"
-version = "0.5.0"
+version = "0.5.1"
 dependencies = [
  "chrono",
  "infr-core",
@@ -1139,7 +1139,7 @@ dependencies = [
 
 [[package]]
 name = "infr-cli"
-version = "0.5.0"
+version = "0.5.1"
 dependencies = [
  "anyhow",
  "clap",
@@ -1163,7 +1163,7 @@ dependencies = [
 
 [[package]]
 name = "infr-core"
-version = "0.5.0"
+version = "0.5.1"
 dependencies = [
  "bytemuck",
  "half",
@@ -1181,7 +1181,7 @@ dependencies = [
 
 [[package]]
 name = "infr-cpu"
-version = "0.5.0"
+version = "0.5.1"
 dependencies = [
  "anyhow",
  "bytemuck",
@@ -1197,7 +1197,7 @@ dependencies = [
 
 [[package]]
 name = "infr-embedding"
-version = "0.5.0"
+version = "0.5.1"
 dependencies = [
  "anyhow",
  "bytemuck",
@@ -1214,7 +1214,7 @@ dependencies = [
 
 [[package]]
 name = "infr-engine"
-version = "0.5.0"
+version = "0.5.1"
 dependencies = [
  "anyhow",
  "infr-chat",
@@ -1228,7 +1228,7 @@ dependencies = [
 
 [[package]]
 name = "infr-gguf"
-version = "0.5.0"
+version = "0.5.1"
 dependencies = [
  "anyhow",
  "bytemuck",
@@ -1244,7 +1244,7 @@ dependencies = [
 
 [[package]]
 name = "infr-gui"
-version = "0.5.0"
+version = "0.5.1"
 dependencies = [
  "anyhow",
  "axum",
@@ -1264,7 +1264,7 @@ dependencies = [
 
 [[package]]
 name = "infr-hub"
-version = "0.5.0"
+version = "0.5.1"
 dependencies = [
  "dirs",
  "indicatif",
@@ -1281,7 +1281,7 @@ dependencies = [
 
 [[package]]
 name = "infr-llama"
-version = "0.5.0"
+version = "0.5.1"
 dependencies = [
  "anyhow",
  "bytemuck",
@@ -1304,7 +1304,7 @@ dependencies = [
 
 [[package]]
 name = "infr-metal"
-version = "0.5.0"
+version = "0.5.1"
 dependencies = [
  "bytemuck",
  "half",
@@ -1320,7 +1320,7 @@ dependencies = [
 
 [[package]]
 name = "infr-prof"
-version = "0.5.0"
+version = "0.5.1"
 dependencies = [
  "proc-macro2",
  "quote",
@@ -1329,11 +1329,11 @@ dependencies = [
 
 [[package]]
 name = "infr-prof-rt"
-version = "0.5.0"
+version = "0.5.1"
 
 [[package]]
 name = "infr-server"
-version = "0.5.0"
+version = "0.5.1"
 dependencies = [
  "anyhow",
  "axum",
@@ -1352,7 +1352,7 @@ dependencies = [
 
 [[package]]
 name = "infr-testkit"
-version = "0.5.0"
+version = "0.5.1"
 dependencies = [
  "bytemuck",
  "half",
@@ -1362,7 +1362,7 @@ dependencies = [
 
 [[package]]
 name = "infr-vulkan"
-version = "0.5.0"
+version = "0.5.1"
 dependencies = [
  "ash",
  "bytemuck",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -20,7 +20,7 @@ members = [
 ]
 
 [workspace.package]
-version = "0.5.0"
+version = "0.5.1"
 edition = "2021"
 license = "Apache-2.0"
 repository = "https://github.com/Headmaster218/MoE4All"

--- a/crates/infr-vulkan/src/adapter.rs
+++ b/crates/infr-vulkan/src/adapter.rs
@@ -477,6 +477,23 @@ fn paged_static_phase(graph: &Graph) -> Option<StaticScratchPhase> {
     phase
 }
 
+fn pager_static_transition(
+    previous: Option<StaticScratchPhase>,
+    next: StaticScratchPhase,
+    moe_layer_stream: bool,
+) -> Option<StaticScratchPhase> {
+    if !moe_layer_stream || previous == Some(next) {
+        return None;
+    }
+    match (previous, next) {
+        (_, StaticScratchPhase::Prefill) => Some(StaticScratchPhase::Prefill),
+        (Some(StaticScratchPhase::Prefill), StaticScratchPhase::Decode) => {
+            Some(StaticScratchPhase::Decode)
+        }
+        _ => None,
+    }
+}
+
 /// mmv (int8 dp4a decode GEMV) size gate for the m≥3 small-m PREFILL mrow path: below this
 /// weight-element count the dequant GEMV is already so short (<~10us) that the extra quant_q8
 /// dispatch's fixed bubble (~2-3us on a 7900 XTX) eats the kernel saving. Probe data
@@ -5912,35 +5929,56 @@ fn abort_segment(rec: Option<Recorder<'_>>, e: Error) -> Error {
 /// retain shape-stable scratch within one decode/prefill phase; other plans allocate it per call.
 #[cfg_attr(infr_profile, infr_prof::instrument)]
 fn execute_static(be_: &VulkanBackend, graph: &Graph, bindings: &Bindings) -> Result<()> {
+    let layout = scratch_layout(graph)?;
     // Paged decode plans are rebuilt per token, but their pooled workspace is shape-stable across
     // the whole decode phase. Retain that pool on the model backend so freeing one token's scratch
     // cannot restore an expert slot that the next token immediately has to borrow again. The
     // existing unified execution gate serializes this model's executes, so the mutex is only a
     // lifetime container rather than a hot-path contention point.
+    let mut scratch_reused = false;
     let mut cached_pool = if be_.moe_paged() {
-        paged_static_phase(graph).map(|phase| {
+        if let Some(phase) = paged_static_phase(graph) {
             let mut cache = be_.static_scratch.lock().unwrap();
+            let pager_transition =
+                pager_static_transition(cache.phase, phase, be_.cfg().paging.moe_layer_stream);
             cache.enter(phase);
-            cache
-        })
+            scratch_reused = cache.scratch_layout == layout && cache.scratch.len() == layout.len();
+            if !scratch_reused {
+                // A same-phase shape change must also release its old scratch before the pager
+                // reserves Prefill lanes; otherwise those live allocations can fragment the arena.
+                cache.scratch.clear();
+                cache.scratch_layout.clear();
+            }
+
+            // Finish the old phase before any scratch or lazy per-op pool for the new phase can
+            // borrow unified VRAM. Prefill reserves/protects its whole-layer lanes; Decode releases
+            // those temporary lanes so all of its allocations see the final Decode topology.
+            if let Some(pager_phase) = pager_transition {
+                let mut guard = be_.moe_pager().lock().unwrap();
+                let sess = guard
+                    .as_mut()
+                    .ok_or_else(|| be("paged static execution requires a MoE pager session"))?;
+                match pager_phase {
+                    StaticScratchPhase::Prefill => sess.enter_prefill_layer()?,
+                    StaticScratchPhase::Decode => {
+                        sess.enter_decode();
+                    }
+                }
+            }
+
+            if !scratch_reused {
+                cache.scratch = alloc_scratch_layout(be_, &layout)?;
+                cache.scratch_layout.clone_from(&layout);
+            }
+            Some(cache)
+        } else {
+            None
+        }
     } else {
         None
     };
-    let layout = scratch_layout(graph)?;
     let mut local_scratch = None;
-    let mut scratch_reused = false;
-    if let Some(cache) = cached_pool.as_mut() {
-        if cache.scratch_layout == layout && cache.scratch.len() == layout.len() {
-            scratch_reused = true;
-        } else {
-            // Release the old layout before allocating the new one so a phase-local shape change
-            // cannot temporarily require both scratch sets from the unified arena.
-            cache.scratch.clear();
-            cache.scratch_layout.clear();
-            cache.scratch = alloc_scratch_layout(be_, &layout)?;
-            cache.scratch_layout.clone_from(&layout);
-        }
-    } else {
+    if cached_pool.is_none() {
         local_scratch = Some(alloc_scratch_layout(be_, &layout)?);
     }
     if scratch_reused {
@@ -8194,6 +8232,42 @@ mod tests {
         assert_eq!(moe_static_phase(16, 8, 512), StaticScratchPhase::Decode);
         assert_eq!(moe_static_phase(191, 8, 512), StaticScratchPhase::Decode);
         assert_eq!(moe_static_phase(192, 8, 512), StaticScratchPhase::Prefill);
+        assert_eq!(
+            pager_static_transition(None, StaticScratchPhase::Decode, true),
+            None
+        );
+        assert_eq!(
+            pager_static_transition(None, StaticScratchPhase::Prefill, true),
+            Some(StaticScratchPhase::Prefill)
+        );
+        assert_eq!(
+            pager_static_transition(
+                Some(StaticScratchPhase::Decode),
+                StaticScratchPhase::Prefill,
+                true
+            ),
+            Some(StaticScratchPhase::Prefill)
+        );
+        assert_eq!(
+            pager_static_transition(
+                Some(StaticScratchPhase::Prefill),
+                StaticScratchPhase::Decode,
+                true
+            ),
+            Some(StaticScratchPhase::Decode)
+        );
+        assert_eq!(
+            pager_static_transition(
+                Some(StaticScratchPhase::Prefill),
+                StaticScratchPhase::Prefill,
+                true
+            ),
+            None
+        );
+        assert_eq!(
+            pager_static_transition(None, StaticScratchPhase::Prefill, false),
+            None
+        );
     }
 
     /// Read a `#define <name> <integer>` back out of GLSL source. Panics when the define is gone —

--- a/crates/infr-vulkan/src/lib.rs
+++ b/crates/infr-vulkan/src/lib.rs
@@ -6059,8 +6059,8 @@ mod tests {
         );
     }
 
-    /// A module allocation may evict cold expert slots, then exact-slot restoration returns every
-    /// byte to the expert cache after the module buffer is released.
+    /// A module allocation may evict cold expert slots, then either execution-phase transition
+    /// returns every released byte to the expert cache before using its slot topology.
     #[test]
     #[ignore = "requires a Vulkan-capable GPU"]
     fn unified_vram_loans_and_restores_expert_slots() {
@@ -6123,6 +6123,28 @@ mod tests {
             .as_mut()
             .expect("pager")
             .enter_decode();
+        let restored = pool.stats();
+        assert_eq!(
+            restored.class_bytes(crate::unified::UnifiedVramClass::Expert),
+            SLOT * SLOTS,
+        );
+        assert_eq!(restored.free_bytes, 0);
+
+        let embedding = embedding_backend
+            .alloc_uninit(SLOT * 2 + SLOT / 2, BufferUsage::Weights)
+            .expect("loan expert slots before Prefill");
+        drop(embedding);
+        let error = be
+            .moe_pager
+            .lock()
+            .unwrap()
+            .as_mut()
+            .expect("pager")
+            .enter_prefill_layer()
+            .expect_err("the synthetic pager has no registered Prefill banks");
+        assert!(error
+            .to_string()
+            .contains("cannot build a prefill layout without expert banks"));
         let restored = pool.stats();
         assert_eq!(
             restored.class_bytes(crate::unified::UnifiedVramClass::Expert),

--- a/crates/infr-vulkan/src/pager.rs
+++ b/crates/infr-vulkan/src/pager.rs
@@ -2523,6 +2523,10 @@ impl MoePagerSession {
     /// invalidated. Everything outside the borrowed lanes survives the phase transition.
     pub fn enter_prefill_layer(&mut self) -> Result<()> {
         if self.mode != MoeArenaMode::PrefillLayer {
+            // Decode/runtime allocations may have released unified ranges after the last
+            // `enter_decode()` call. Reclaim those exact Expert slots before measuring the
+            // contiguous ranges available to the next Prefill lane.
+            self.restore_unified_slots_if_changed();
             self.build_prefill_layout()?;
             let mut evicted = 0usize;
             let mut borrowed = 0usize;


### PR DESCRIPTION
MoE4All v0.5.1 是基于 v0.5.0 的稳定性修复版本，包含 v0.5.0 的全部功能与性能改进。

## 新增修复

- 修复 Vulkan MoE 模型在长上下文 Prefill 期间可能出现的统一显存碎片与分配失败。
- MoE Prefill 现在会在 phase scratch 分配前预留完整层所需的连续 lane，避免动态 KV Cache 扩展过程中显存布局变化导致 Prefill 无法获得连续工作区。
- 修复不会改变分页策略、专家缓存容量、KV 数据类型或模型计算结果。

该问题已由用户使用原始复现提示词连续测试 3 次，全部成功完成，未再复现。

## v0.5.0 基础更新

- Qwen3.5、Qwen3.6 与 Qwen3.8-Flash-Next 的 Vulkan KV Cache 支持按 32K token 分段动态增长。
- 兼容的 Vulkan 模型默认使用 Q8_0 K/V Cache，显著降低长上下文显存占用。
- Qwen3.8 QSA 状态采用动态分段分配。
- 修复 Q8 KV 预算、运行时分配和显存统计不一致的问题。
- Chunk-major Prefill 恢复为默认执行模式。
- 优化 Qwen3.8 QSA、Q8 Attention、MoE Top-K 与 Q2 专家 Prefill 性能。

## 已知限制

动态分段 KV Cache 当前主要适用于 Vulkan 上支持耦合 Q8_0 K/V 的 Qwen 模型。显式 F16 或混合 K/V 配置仍使用原有的平坦分配方式。